### PR TITLE
Version 2 api urls, error fixes and "likes", "dislikes" added to rating

### DIFF
--- a/lib/youtube_it/client.rb
+++ b/lib/youtube_it/client.rb
@@ -12,7 +12,7 @@ class YouTubeIt
         @client_id             = hash_options[:client_id] || "youtube_it"
         @legacy_debug_flag     = hash_options[:debug]
       else
-        puts "* warning: the method YouTubeIt::Client.new(user, passwd, dev_key) is depricated, use YouTubeIt::Client.new(:username => 'user', :password => 'passwd', :dev_key => 'dev_key')"
+        puts "* warning: the method YouTubeIt::Client.new(user, passwd, dev_key) is deprecated, use YouTubeIt::Client.new(:username => 'user', :password => 'passwd', :dev_key => 'dev_key')"
         @user               = params.shift
         @pass               = params.shift
         @dev_key            = params.shift

--- a/lib/youtube_it/model/rating.rb
+++ b/lib/youtube_it/model/rating.rb
@@ -12,6 +12,12 @@ class YouTubeIt
       
       # *Fixnum*:: Indicates how many people have rated the video
       attr_reader :rater_count
+
+      # *Fixnum*:: Indicates how many people likes this video
+      attr_reader :likes
+
+      # *Fixnum*:: Indicates how many people dislikes this video
+      attr_reader :dislikes
     end
   end
 end

--- a/lib/youtube_it/request/standard_search.rb
+++ b/lib/youtube_it/request/standard_search.rb
@@ -32,7 +32,8 @@ class YouTubeIt
           'max-results' => @max_results,
           'orderby' => @order_by,
           'start-index' => @offset,
-          'time' => @time
+          'time' => @time,
+          'v' => 2
         }
       end
     end

--- a/lib/youtube_it/request/user_search.rb
+++ b/lib/youtube_it/request/user_search.rb
@@ -34,7 +34,8 @@ class YouTubeIt
         {
           'max-results' => @max_results,
           'orderby' => @order_by,
-          'start-index' => @offset
+          'start-index' => @offset,
+          'v' => 2
         }
       end
     end

--- a/lib/youtube_it/request/video_search.rb
+++ b/lib/youtube_it/request/video_search.rb
@@ -28,7 +28,7 @@ class YouTubeIt
         @dev_key = params[:dev_key] if params[:dev_key]
 
         # Return a single video (base_url + /T7YazwP8GtY)
-        return @url << "/" << params[:video_id] if params[:video_id]
+        return @url << "/" << params[:video_id] << "?v=2" if params[:video_id]
 
         @url << "/-/" if (params[:categories] || params[:tags])
         @url << categories_to_params(params.delete(:categories)) if params[:categories]
@@ -54,7 +54,8 @@ class YouTubeIt
           'max-results' => @max_results,
           'orderby' => @order_by,
           'start-index' => @offset,
-          'vq' => @query,
+          'v' => 2,
+          'q' => @query,
           'alt' => @response_format,
           'format' => @video_format,
           'racy' => @racy,

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -16,7 +16,7 @@ class TestClient < Test::Unit::TestCase
   def test_should_respond_to_a_basic_query
     response = @client.videos_by(:query => "penguin")
   
-    assert_equal "http://gdata.youtube.com/feeds/api/videos", response.feed_id
+    assert_equal "tag:youtube.com,2008:videos", response.feed_id
     assert_equal 25, response.max_result_count
     assert_equal 25, response.videos.length
     assert_equal 1, response.offset
@@ -29,7 +29,7 @@ class TestClient < Test::Unit::TestCase
     def test_should_respond_to_a_basic_query_with_offset_and_max_results
     response = @client.videos_by(:query => "penguin", :offset => 15, :max_results => 30)
   
-    assert_equal "http://gdata.youtube.com/feeds/api/videos", response.feed_id
+    assert_equal "tag:youtube.com,2008:videos", response.feed_id
     assert_equal 30, response.max_result_count
     assert_equal 30, response.videos.length
     assert_equal 15, response.offset
@@ -41,17 +41,17 @@ class TestClient < Test::Unit::TestCase
   
   def test_should_respond_to_a_basic_query_with_paging
     response = @client.videos_by(:query => "penguin")
-    assert_equal "http://gdata.youtube.com/feeds/api/videos", response.feed_id
+    assert_equal "tag:youtube.com,2008:videos", response.feed_id
     assert_equal 25, response.max_result_count
     assert_equal 1, response.offset
   
       response = @client.videos_by(:query => "penguin", :page => 2)
-    assert_equal "http://gdata.youtube.com/feeds/api/videos", response.feed_id
+    assert_equal "tag:youtube.com,2008:videos", response.feed_id
     assert_equal 25, response.max_result_count
     assert_equal 26, response.offset
   
     response2 = @client.videos_by(:query => "penguin", :page => 3)
-    assert_equal "http://gdata.youtube.com/feeds/api/videos", response2.feed_id
+    assert_equal "tag:youtube.com,2008:videos", response2.feed_id
     assert_equal 25, response2.max_result_count
     assert_equal 51, response2.offset
   end
@@ -59,7 +59,7 @@ class TestClient < Test::Unit::TestCase
   def test_should_get_videos_for_multiword_metasearch_query
     response = @client.videos_by(:query => 'christina ricci')
   
-    assert_equal "http://gdata.youtube.com/feeds/api/videos", response.feed_id
+    assert_equal "tag:youtube.com,2008:videos", response.feed_id
     assert_equal 25, response.max_result_count
     assert_equal 25, response.videos.length
     assert_equal 1, response.offset
@@ -139,7 +139,7 @@ class TestClient < Test::Unit::TestCase
   
   def test_should_get_favorite_videos_by_user
     response = @client.videos_by(:favorites, :user => 'drnicwilliams')
-    assert_equal "http://gdata.youtube.com/feeds/api/users/drnicwilliams/favorites", response.feed_id
+    assert_equal "tag:youtube.com,2008:user:drnicwilliams:favorites", response.feed_id
     response.videos.each { |v| assert_valid_video v }
   end
   

--- a/test/test_video_search.rb
+++ b/test/test_video_search.rb
@@ -4,79 +4,79 @@ class TestVideoSearch < Test::Unit::TestCase
 
   def test_should_build_basic_query_url
     request = YouTubeIt::Request::VideoSearch.new(:query => "penguin")
-    assert_equal "http://gdata.youtube.com/feeds/api/videos?vq=penguin", request.url
+    assert_equal "http://gdata.youtube.com/feeds/api/videos?q=penguin&v=2", request.url
   end
 
   def test_should_build_multiword_metasearch_query_url
     request = YouTubeIt::Request::VideoSearch.new(:query => 'christina ricci')
-    assert_equal "http://gdata.youtube.com/feeds/api/videos?vq=christina+ricci", request.url
+    assert_equal "http://gdata.youtube.com/feeds/api/videos?q=christina+ricci&v=2", request.url
   end
 
   def test_should_build_video_id_url
     request = YouTubeIt::Request::VideoSearch.new(:video_id => 'T7YazwP8GtY')
-    assert_equal "http://gdata.youtube.com/feeds/api/videos/T7YazwP8GtY", request.url
+    assert_equal "http://gdata.youtube.com/feeds/api/videos/T7YazwP8GtY?v=2", request.url
   end
 
-  def test_should_build_one_tag_querl_url
+  def test_should_build_one_tag_query_url
     request = YouTubeIt::Request::VideoSearch.new(:tags => ['panther'])
-    assert_equal "http://gdata.youtube.com/feeds/api/videos/-/panther/", request.url
+    assert_equal "http://gdata.youtube.com/feeds/api/videos/-/panther/?v=2", request.url
   end
 
   def test_should_build_multiple_tags_query_url
     request = YouTubeIt::Request::VideoSearch.new(:tags => ['tiger', 'leopard'])
-    assert_equal "http://gdata.youtube.com/feeds/api/videos/-/tiger/leopard/", request.url
+    assert_equal "http://gdata.youtube.com/feeds/api/videos/-/tiger/leopard/?v=2", request.url
   end
 
   def test_should_build_one_category_query_url
     request = YouTubeIt::Request::VideoSearch.new(:categories => [:news])
-    assert_equal "http://gdata.youtube.com/feeds/api/videos/-/News/", request.url
+    assert_equal "http://gdata.youtube.com/feeds/api/videos/-/News/?v=2", request.url
   end
 
   def test_should_build_multiple_categories_query_url
     request = YouTubeIt::Request::VideoSearch.new(:categories => [:news, :sports])
-    assert_equal "http://gdata.youtube.com/feeds/api/videos/-/News/Sports/", request.url
+    assert_equal "http://gdata.youtube.com/feeds/api/videos/-/News/Sports/?v=2", request.url
   end
 
   def test_should_build_categories_and_tags_query_url
     request = YouTubeIt::Request::VideoSearch.new(:categories => [:news, :sports], :tags => ['soccer', 'football'])
-    assert_equal "http://gdata.youtube.com/feeds/api/videos/-/News/Sports/soccer/football/", request.url
+    assert_equal "http://gdata.youtube.com/feeds/api/videos/-/News/Sports/soccer/football/?v=2", request.url
   end
 
   def test_should_build_categories_and_tags_url_with_max_results
     request = YouTubeIt::Request::VideoSearch.new(:categories => [:music], :tags => ['classic', 'rock'], :max_results => 2)
-    assert_equal "http://gdata.youtube.com/feeds/api/videos/-/Music/classic/rock/?max-results=2", request.url
+    assert_equal "http://gdata.youtube.com/feeds/api/videos/-/Music/classic/rock/?max-results=2&v=2", request.url
   end
 
   def test_should_build_author_query_url
     request = YouTubeIt::Request::VideoSearch.new(:author => "davidguetta")
-    assert_equal "http://gdata.youtube.com/feeds/api/videos?author=davidguetta", request.url
+    assert_equal "http://gdata.youtube.com/feeds/api/videos?author=davidguetta&v=2", request.url
   end
 
   def test_should_build_language_query_url
     request = YouTubeIt::Request::VideoSearch.new(:query => 'christina ricci', :lang => 'pt')
-    assert_equal "http://gdata.youtube.com/feeds/api/videos?lr=pt&vq=christina+ricci", request.url
+    assert_equal "http://gdata.youtube.com/feeds/api/videos?lr=pt&q=christina+ricci&v=2", request.url
   end
 
   # -- Standard Feeds --------------------------------------------------------------------------------
 
   def test_should_build_url_for_most_viewed
     request = YouTubeIt::Request::StandardSearch.new(:most_viewed)
-    assert_equal "http://gdata.youtube.com/feeds/api/standardfeeds/most_viewed", request.url
+    assert_equal "http://gdata.youtube.com/feeds/api/standardfeeds/most_viewed?v=2", request.url
   end
 
   def test_should_build_url_for_top_rated_for_today
     request = YouTubeIt::Request::StandardSearch.new(:top_rated, :time => :today)
-    assert_equal "http://gdata.youtube.com/feeds/api/standardfeeds/top_rated?time=today", request.url
+    assert_equal "http://gdata.youtube.com/feeds/api/standardfeeds/top_rated?time=today&v=2", request.url
   end
 
   def test_should_build_url_for_most_viewed_offset_and_max_results_without_time
     request = YouTubeIt::Request::StandardSearch.new(:top_rated, :offset => 5, :max_results => 10)
-    assert_equal "http://gdata.youtube.com/feeds/api/standardfeeds/top_rated?max-results=10&start-index=5", request.url
+    assert_equal "http://gdata.youtube.com/feeds/api/standardfeeds/top_rated?max-results=10&start-index=5&v=2", request.url
   end
 
   def test_should_build_url_for_most_viewed_offset_and_max_results_with_time
     request = YouTubeIt::Request::StandardSearch.new(:top_rated, :offset => 5, :max_results => 10, :time => :today)
-    assert_equal "http://gdata.youtube.com/feeds/api/standardfeeds/top_rated?max-results=10&start-index=5&time=today", request.url
+    assert_equal "http://gdata.youtube.com/feeds/api/standardfeeds/top_rated?max-results=10&start-index=5&time=today&v=2", request.url
   end
 
   def test_should_raise_exception_for_invalid_type
@@ -89,53 +89,52 @@ class TestVideoSearch < Test::Unit::TestCase
 
   def test_should_build_url_for_boolean_or_case_for_categories
     request = YouTubeIt::Request::VideoSearch.new(:categories => { :either => [:news, :sports] })
-    assert_equal "http://gdata.youtube.com/feeds/api/videos/-/News%7CSports/", request.url
+    assert_equal "http://gdata.youtube.com/feeds/api/videos/-/News%7CSports/?v=2", request.url
   end
 
   def test_should_build_url_for_boolean_or_and_exclude_case_for_categories
     request = YouTubeIt::Request::VideoSearch.new(:categories => { :either => [:news, :sports], :exclude => [:comedy] })
-    assert_equal "http://gdata.youtube.com/feeds/api/videos/-/News%7CSports/-Comedy/", request.url
+    assert_equal "http://gdata.youtube.com/feeds/api/videos/-/News%7CSports/-Comedy/?v=2", request.url
   end
 
   def test_should_build_url_for_exclude_case_for_tags
     request = YouTubeIt::Request::VideoSearch.new(:categories => { :either => [:news, :sports], :exclude => [:comedy] },
                                                  :tags => { :include => ['football'], :exclude => ['soccer'] })
-    assert_equal "http://gdata.youtube.com/feeds/api/videos/-/News%7CSports/-Comedy/football/-soccer/", request.url
+    assert_equal "http://gdata.youtube.com/feeds/api/videos/-/News%7CSports/-Comedy/football/-soccer/?v=2", request.url
   end
 
   def test_should_build_url_for_either_case_for_tags
     request = YouTubeIt::Request::VideoSearch.new(:categories => { :either => [:news, :sports], :exclude => [:comedy] },
                                                  :tags => { :either => ['soccer', 'football', 'donkey'] })
-    assert_equal "http://gdata.youtube.com/feeds/api/videos/-/News%7CSports/-Comedy/soccer%7Cfootball%7Cdonkey/", request.url
+    assert_equal "http://gdata.youtube.com/feeds/api/videos/-/News%7CSports/-Comedy/soccer%7Cfootball%7Cdonkey/?v=2", request.url
   end
 
   def test_should_build_url_for_query_search_with_categories_excluded
     request = YouTubeIt::Request::VideoSearch.new(:query => 'bench press',
                                                  :categories => { :exclude => [:comedy, :entertainment] },
                                                  :max_results => 10)
-    assert_equal "http://gdata.youtube.com/feeds/api/videos/-/-Comedy/-Entertainment/?max-results=10&vq=bench+press", request.url
+    assert_equal "http://gdata.youtube.com/feeds/api/videos/-/-Comedy/-Entertainment/?max-results=10&q=bench+press&v=2", request.url
   end
 
   # -- User Queries ---------------------------------------------------------------------------------
 
   def test_should_build_url_for_videos_by_user
     request = YouTubeIt::Request::UserSearch.new(:user => 'liz')
-    assert_equal "http://gdata.youtube.com/feeds/api/users/liz/uploads", request.url
+    assert_equal "http://gdata.youtube.com/feeds/api/users/liz/uploads?v=2", request.url
   end
 
   def test_should_build_url_for_videos_by_user_paginate_and_order
     request = YouTubeIt::Request::UserSearch.new(:user => 'liz', :offset => 20, :max_results => 10, :order_by => 'published')
-    assert_equal "http://gdata.youtube.com/feeds/api/users/liz/uploads?max-results=10&orderby=published&start-index=20", request.url
+    assert_equal "http://gdata.youtube.com/feeds/api/users/liz/uploads?max-results=10&orderby=published&start-index=20&v=2", request.url
   end
 
   def test_should_build_url_for_favorite_videos_by_user
     request = YouTubeIt::Request::UserSearch.new(:favorites, :user => 'liz')
-    assert_equal "http://gdata.youtube.com/feeds/api/users/liz/favorites", request.url
+    assert_equal "http://gdata.youtube.com/feeds/api/users/liz/favorites?v=2", request.url
   end
 
   def test_should_build_url_for_favorite_videos_by_user_paginate
     request = YouTubeIt::Request::UserSearch.new(:favorites, :user => 'liz', :offset => 20, :max_results => 10)
-    assert_equal "http://gdata.youtube.com/feeds/api/users/liz/favorites?max-results=10&start-index=20", request.url
+    assert_equal "http://gdata.youtube.com/feeds/api/users/liz/favorites?max-results=10&start-index=20&v=2", request.url
   end
 end
-


### PR DESCRIPTION
I edited urls so that they use always version 2 youtube api. This way we can get some more data like 'likes' and 'dislikes' of the youtube videos, I also added these attributes to Rating class.

There was also a parsing error when video is not available in the region. I fixed the error, video metadata for unavailable video is still fetched and things like duration is set to 0.
