### PR TITLE
Video#unique_id fix and some video feed parser tests

### DIFF
--- a/lib/youtube_it/model/video.rb
+++ b/lib/youtube_it/model/video.rb
@@ -122,8 +122,6 @@ class YouTubeIt
       attr_reader :latitude
       attr_reader :longitude
 
-      attr_reader :statistics
-
       # Videos related to the current video.
       #
       # === Returns
@@ -150,7 +148,7 @@ class YouTubeIt
       # === Returns
       #   String: The Youtube video id.
       def unique_id
-        video_id[/videos\/([^<]+)/, 1]
+        video_id[/videos\/([^<]+)/, 1] || video_id[/video\:([^<]+)/, 1]
       end
 
       # Allows you to check whether the video can be embedded on a webpage.

--- a/test/files/youtube_video_response.xml
+++ b/test/files/youtube_video_response.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <entry xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/" xmlns:gd="http://schemas.google.com/g/2005" xmlns:yt="http://gdata.youtube.com/schemas/2007" gd:etag="W/&quot;A0UBR347eCp7ImA9Wx9bFEs.&quot;">
-	<id>tag:youtube.com,2008:video:TESTVIDEO</id>
+	<id>tag:youtube.com,2008:video:AbC123DeFgH</id>
 	<published>2010-12-29T13:57:49.000Z</published>
 	<updated>2011-02-23T13:54:16.000Z</updated>
 	<category scheme="http://schemas.google.com/g/2005#kind" term="http://gdata.youtube.com/schemas/2007#video"/>
 	<category scheme="http://gdata.youtube.com/schemas/2007/categories.cat" term="Test" label="Test"/>
 	<category scheme="http://gdata.youtube.com/schemas/2007/keywords.cat" term="test"/>
 	<title>YouTube Test Video</title>
-	<content type="application/x-shockwave-flash" src="http://www.youtube.com/v/YTTESTVIDEO?f=videos&amp;app=youtube_gdata"/>
-	<link rel="alternate" type="text/html" href="http://www.youtube.com/watch?v=YTTESTVIDEO&amp;feature=youtube_gdata"/>
-	<link rel="http://gdata.youtube.com/schemas/2007#video.responses" type="application/atom+xml" href="http://gdata.youtube.com/feeds/api/videos/YTTESTVIDEO/responses?v=2"/>
-	<link rel="http://gdata.youtube.com/schemas/2007#video.related" type="application/atom+xml" href="http://gdata.youtube.com/feeds/api/videos/YTTESTVIDEO/related?v=2"/>
-	<link rel="http://gdata.youtube.com/schemas/2007#mobile" type="text/html" href="http://m.youtube.com/details?v=YTTESTVIDEO"/>
-	<link rel="self" type="application/atom+xml" href="http://gdata.youtube.com/feeds/api/videos/YTTESTVIDEO?v=2"/>
+	<content type="application/x-shockwave-flash" src="http://www.youtube.com/v/YTAbC123DeF?f=videos&amp;app=youtube_gdata"/>
+	<link rel="alternate" type="text/html" href="http://www.youtube.com/watch?v=AbC123DeFgH&amp;feature=youtube_gdata"/>
+	<link rel="http://gdata.youtube.com/schemas/2007#video.responses" type="application/atom+xml" href="http://gdata.youtube.com/feeds/api/videos/AbC123DeFgH/responses?v=2"/>
+	<link rel="http://gdata.youtube.com/schemas/2007#video.related" type="application/atom+xml" href="http://gdata.youtube.com/feeds/api/videos/AbC123DeFgH/related?v=2"/>
+	<link rel="http://gdata.youtube.com/schemas/2007#mobile" type="text/html" href="http://m.youtube.com/details?v=AbC123DeFgH"/>
+	<link rel="self" type="application/atom+xml" href="http://gdata.youtube.com/feeds/api/videos/AbC123DeFgH?v=2"/>
 	<author>
 		<name>Test user</name>
 		<uri>http://gdata.youtube.com/feeds/api/users/test_user</uri>
@@ -25,27 +25,27 @@
 	<yt:accessControl action="list" permission="allowed"/>
 	<yt:accessControl action="syndicate" permission="allowed"/>
 	<gd:comments>
-		<gd:feedLink href="http://gdata.youtube.com/feeds/api/videos/YTTESTVIDEO/comments?v=2" countHint="1000"/>
+		<gd:feedLink href="http://gdata.youtube.com/feeds/api/videos/AbC123DeFgH/comments?v=2" countHint="1000"/>
 	</gd:comments>
 	<media:group>
 		<media:category label="Sports" scheme="http://gdata.youtube.com/schemas/2007/categories.cat">Test</media:category>
-		<media:content url="http://www.youtube.com/v/YTTESTVIDEO?f=videos&amp;app=youtube_gdata" type="application/x-shockwave-flash" medium="video" isDefault="true" expression="full" duration="356" yt:format="5"/>
-		<media:content url="rtsp://v7.cache6.c.youtube.com/YTTESTCACHE/0/0/0/video.3gp" type="video/3gpp" medium="video" expression="full" duration="356" yt:format="1"/>
-		<media:content url="rtsp://v8.cache7.c.youtube.com/YTTESTCACHE/0/0/0/video.3gp" type="video/3gpp" medium="video" expression="full" duration="356" yt:format="6"/>
+		<media:content url="http://www.youtube.com/v/AbC123DeFgH?f=videos&amp;app=youtube_gdata" type="application/x-shockwave-flash" medium="video" isDefault="true" expression="full" duration="356" yt:format="5"/>
+		<media:content url="rtsp://v7.cache6.c.youtube.com/TESTCACHE/0/0/0/video.3gp" type="video/3gpp" medium="video" expression="full" duration="356" yt:format="1"/>
+		<media:content url="rtsp://v8.cache7.c.youtube.com/TESTCACHE/0/0/0/video.3gp" type="video/3gpp" medium="video" expression="full" duration="356" yt:format="6"/>
 		<media:credit role="uploader" scheme="urn:youtube" yt:type="partner">Test user</media:credit>
 		<media:description type="plain">Youtube Test Video</media:description>
 		<media:keywords>Test, Youtube, Youtube_it, Ruby</media:keywords>
-		<media:player url="http://www.youtube.com/watch?v=YTTESTVIDEO&amp;feature=youtube_gdata_player"/>
-		<media:thumbnail url="http://i.ytimg.com/vi/YTTESTVIDEO/default.jpg" height="90" width="120" time="00:02:58" yt:name="default"/>
-		<media:thumbnail url="http://i.ytimg.com/vi/YTTESTVIDEO/hqdefault.jpg" height="360" width="480" yt:name="hqdefault"/>
-		<media:thumbnail url="http://i.ytimg.com/vi/YTTESTVIDEO/1.jpg" height="90" width="120" time="00:01:29" yt:name="start"/>
-		<media:thumbnail url="http://i.ytimg.com/vi/YTTESTVIDEO/2.jpg" height="90" width="120" time="00:02:58" yt:name="middle"/>
-		<media:thumbnail url="http://i.ytimg.com/vi/YTTESTVIDEO/3.jpg" height="90" width="120" time="00:04:27" yt:name="end"/>
+		<media:player url="http://www.youtube.com/watch?v=AbC123DeFgH&amp;feature=youtube_gdata_player"/>
+		<media:thumbnail url="http://i.ytimg.com/vi/AbC123DeFgH/default.jpg" height="90" width="120" time="00:02:58" yt:name="default"/>
+		<media:thumbnail url="http://i.ytimg.com/vi/AbC123DeFgH/hqdefault.jpg" height="360" width="480" yt:name="hqdefault"/>
+		<media:thumbnail url="http://i.ytimg.com/vi/AbC123DeFgH/1.jpg" height="90" width="120" time="00:01:29" yt:name="start"/>
+		<media:thumbnail url="http://i.ytimg.com/vi/AbC123DeFgH/2.jpg" height="90" width="120" time="00:02:58" yt:name="middle"/>
+		<media:thumbnail url="http://i.ytimg.com/vi/AbC123DeFgH/3.jpg" height="90" width="120" time="00:04:27" yt:name="end"/>
 		<media:title type="plain">Ich sterbe für YouTube</media:title>
 		<yt:aspectRatio>widescreen</yt:aspectRatio>
 		<yt:duration seconds="356"/>
 		<yt:uploaded>2010-12-29T13:57:49.000Z</yt:uploaded>
-		<yt:videoid>YTTESTVIDEO</yt:videoid>
+		<yt:videoid>AbC123DeFgH</yt:videoid>
 	</media:group>
 	<gd:rating average="4.305027" max="5" min="1" numRaters="2049" rel="http://schemas.google.com/g/2005#overall"/>
 	<yt:statistics favoriteCount="200" viewCount="240000"/>

--- a/test/test_video.rb
+++ b/test/test_video.rb
@@ -2,17 +2,17 @@ require File.dirname(__FILE__) + '/helper'
 
 class TestVideo < Test::Unit::TestCase
   def test_should_extract_unique_id_from_video_id
-    video = YouTubeIt::Model::Video.new(:video_id => "http://gdata.youtube.com/feeds/videos/ZTUVgYoeN_o")
+    video = YouTubeIt::Model::Video.new(:video_id => "tag:youtube.com,2008:video:ZTUVgYoeN_o")
     assert_equal "ZTUVgYoeN_o", video.unique_id
   end
 
   def test_should_extract_unique_id_with_hypen_from_video_id
-    video = YouTubeIt::Model::Video.new(:video_id => "http://gdata.youtube.com/feeds/videos/BDqs-OZWw9o")
+    video = YouTubeIt::Model::Video.new(:video_id => "tag:youtube.com,2008:video:BDqs-OZWw9o")
     assert_equal "BDqs-OZWw9o", video.unique_id
   end
 
   def test_should_have_related_videos
-    video = YouTubeIt::Model::Video.new(:video_id => "http://gdata.youtube.com/feeds/videos/BDqs-OZWw9o")
+    video = YouTubeIt::Model::Video.new(:video_id => "tag:youtube.com,2008:video:BDqs-OZWw9o")
     response = video.related
 
     assert_equal "http://gdata.youtube.com/feeds/api/videos/BDqs-OZWw9o/related", response.feed_id
@@ -24,7 +24,7 @@ class TestVideo < Test::Unit::TestCase
   end
 
   def test_should_have_response_videos
-    video = YouTubeIt::Model::Video.new(:video_id => "http://gdata.youtube.com/feeds/videos/BDqs-OZWw9o")
+    video = YouTubeIt::Model::Video.new(:video_id => "tag:youtube.com,2008:video:BDqs-OZWw9o")
     response = video.responses
 
     assert_equal "http://gdata.youtube.com/feeds/api/videos/BDqs-OZWw9o/responses", response.feed_id
@@ -36,7 +36,7 @@ class TestVideo < Test::Unit::TestCase
   end
 
   def test_should_scale_video_embed
-    video = YouTubeIt::Model::Video.new(:video_id => "http://gdata.youtube.com/feeds/videos/EkF4JD2rO3Q", :player_url=>"http://www.youtube.com/v/EkF4JD2rO3Q&feature=youtube_gdata_player", :widescreen => true)
+    video = YouTubeIt::Model::Video.new(:video_id => "tag:youtube.com,2008:video:EkF4JD2rO3Q", :player_url=>"http://www.youtube.com/v/EkF4JD2rO3Q&feature=youtube_gdata_player", :widescreen => true)
     assert_equal "<object width=\"1280\" height=\"745\">\n<param name=\"movie\" value=\"http://www.youtube.com/v/EkF4JD2rO3Q&feature=youtube_gdata_player\"></param>\n<param name=\"wmode\" value=\"transparent\"></param>\n<embed src=\"http://www.youtube.com/v/EkF4JD2rO3Q&feature=youtube_gdata_player\" type=\"application/x-shockwave-flash\"\nwmode=\"transparent\" width=\"1280\" height=\"745\"></embed>\n</object>\n", video.embed_html_with_width(1280)
   end
 end

--- a/test/test_video_feed_parser.rb
+++ b/test/test_video_feed_parser.rb
@@ -1,6 +1,164 @@
 require File.dirname(__FILE__) + '/helper'
 
 class TestVideoFeedParser < Test::Unit::TestCase
+
+  # VIDEO ATTRIBUTES AFFECTED BY PARSING
+
+  def test_should_display_unique_id_correctly_after_parsing
+    with_video_response do |parser|
+      video = parser.parse
+      assert_equal "AbC123DeFgH", video.unique_id
+    end
+  end
+
+  # PARSED VIDEO ATTRIBUTES
+  def test_should_parse_duration_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      assert_equal 356, video.duration
+    end
+  end
+
+  def test_should_parse_widescreen_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      assert_equal true, video.widescreen?
+    end
+  end
+
+  def test_should_parse_noembed_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      assert_equal false, video.noembed
+    end
+  end
+
+  def test_should_parse_racy_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      assert_equal false, video.racy
+    end
+  end
+
+  def test_should_parse_video_id_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      assert_equal "tag:youtube.com,2008:video:AbC123DeFgH", video.video_id
+    end
+  end
+
+  def test_should_parse_published_at_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      assert_equal Time.parse("Wed Dec 29 13:57:49 UTC 2010"), video.published_at
+    end
+  end
+
+  def test_should_parse_updated_at_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      assert_equal Time.parse("Wed Feb 23 13:54:16 UTC 2011"), video.updated_at
+    end
+  end
+  
+  def test_should_parse_categories_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      assert_equal "Test", video.categories.first.label
+      assert_equal "Test", video.categories.first.term
+    end
+  end
+
+  def test_should_parse_keywords_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      assert_equal ["test"], video.keywords
+    end
+  end
+
+  def test_should_parse_description_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      assert_equal "Youtube Test Video", video.description
+    end
+  end
+
+  def test_should_parse_title_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      assert_equal "YouTube Test Video", video.title
+    end
+  end
+
+  def test_should_parse_html_content_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      assert_equal nil, video.html_content
+    end
+  end
+
+  def test_should_parse_thumbnails_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      thumbnail = video.thumbnails.first
+      assert_equal 90, thumbnail.height
+      assert_equal "00:02:58", thumbnail.time
+      assert_equal "http://i.ytimg.com/vi/AbC123DeFgH/default.jpg", thumbnail.url
+      assert_equal 120, thumbnail.width
+    end
+  end
+
+  def test_should_parse_player_url_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      assert_equal "http://www.youtube.com/watch?v=AbC123DeFgH&feature=youtube_gdata_player", video.player_url
+    end
+  end
+
+  def test_should_parse_view_count_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      assert_equal 240000, video.view_count
+    end
+  end
+
+  def test_should_parse_favorite_count_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      assert_equal 200, video.favorite_count
+    end
+  end
+
+  # RATING
+
+  def test_should_parse_average_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      assert_equal 4.305027, video.rating.average
+    end
+  end
+
+  def test_should_parse_max_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      assert_equal 5, video.rating.max
+    end
+  end
+
+  def test_should_parse_min_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      assert_equal 1, video.rating.min
+    end
+  end
+
+  def test_should_parse_rater_count_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      assert_equal 2049, video.rating.rater_count
+    end
+  end
+
   def test_should_parse_likes_correctly
     with_video_response do |parser|
       video = parser.parse
@@ -12,6 +170,86 @@ class TestVideoFeedParser < Test::Unit::TestCase
     with_video_response do |parser|
       video = parser.parse
       assert_equal 350, video.rating.dislikes
+    end
+  end
+  
+  # TOD: GEODATA
+
+  def test_should_parse_where_geodata_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      assert_equal nil, video.where
+    end
+  end
+  
+  def test_should_parse_position_geodata_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      assert_equal nil, video.position
+    end
+  end
+  
+  def test_should_parse_latitude_geodata_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      assert_equal nil, video.latitude
+    end
+  end
+  
+  def test_should_parse_longitude_geodata_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      assert_equal nil, video.longitude
+    end
+  end
+
+  # AUTHOR
+
+  def test_should_parse_author_name_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      assert_equal "Test user", video.author.name
+    end
+  end
+
+  def test_should_parse_author_uri_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      assert_equal "http://gdata.youtube.com/feeds/api/users/test_user", video.author.uri
+    end
+  end
+
+  # MEDIA CONTENT
+
+  def test_should_parse_if_media_content_is_default_content_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      content = video.media_content.first
+      assert_equal true, content.default
+    end
+  end
+
+  def test_should_parse_duration_of_media_contents_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      content = video.media_content.first
+      assert_equal 356, content.duration
+    end
+  end
+  
+  def test_should_parse_mime_type_of_media_content_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      content = video.media_content.first
+      assert_equal "application/x-shockwave-flash", content.mime_type
+    end
+  end
+
+  def test_should_parse_url_of_media_content_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      content = video.media_content.first
+      assert_equal "http://www.youtube.com/v/AbC123DeFgH?f=videos&app=youtube_gdata", content.url
     end
   end
 


### PR DESCRIPTION
Added some more tests since unique_id error went unnoticed by test suite. Fixed Video#unique_id, that was not working with new type of id (<id>tag:youtube.com,2008:video:ABCDEFG</id>), it still also works with old url id.
Removed Video#statistics since it seems that it is not used.
