### PR TITLE
Problem with YouTubeIt::Upload::AuthenticationError

### DIFF
--- a/lib/youtube_it/request/video_upload.rb
+++ b/lib/youtube_it/request/video_upload.rb
@@ -472,22 +472,26 @@ class YouTubeIt
               msg_error = error.elements["internalReason"].text
             elsif error.elements["location"]
               msg_error = error.elements["location"].text[/media:group\/media:(.*)\/text\(\)/,1]
+            else
+              msg_error = "Unspecified error"
             end
             code = error.elements["code"].text if error.elements["code"]
             all_faults + sprintf("%s: %s\n", msg_error, code)
           end
         rescue
-          string
+          string[/<TITLE>(.+)<\/TITLE>/, 1] || string 
         end
       end
 
       def raise_on_faulty_response(response)
         response_code = response.code.to_i
+        msg = parse_upload_error_from(response.body.gsub(/\n/, ''))
+
         if response_code == 403 || response_code == 401
         #if response_code / 10 == 40
-          raise AuthenticationError, response.body[/<TITLE>(.+)<\/TITLE>/, 1]
+          raise AuthenticationError, msg
         elsif response_code / 10 != 20 # Response in 20x means success
-          raise UploadError, parse_upload_error_from(response.body.gsub(/\n/,''))
+          raise UploadError, msg
         end
       end
 


### PR DESCRIPTION
Hi, Kyle!

So, here's the problem. When youtube responses me with something like:

```
<errors xmlns='http://schemas.google.com/g/2005'><error><domain>GData</domain><code>ServiceForbiddenException</code><internalReason>Not an owner of the video</internalReason></error></errors>
```

or this:

```
<?xml version='1.0' encoding='UTF-8'?><errors><error><domain>yt:quota</domain><code>too_many_recent_calls</code></error></errors>
```

then youtube_it parsed the response with:

```
raise AuthenticationError, response.body[/<TITLE>(.+)<\/TITLE>/, 1]
```

(https://github.com/kylejginavan/youtube_it/blob/00378b40/lib/youtube_it/request/video_upload.rb#L488)

Which of course didn't work.

I hope my fix will be of some help. Thanks!
