### PR TITLE
fixed Video#embed_html5 HTML syntax error lack of </iframe>

### DIFF
--- a/lib/youtube_it/model/video.rb
+++ b/lib/youtube_it/model/video.rb
@@ -203,7 +203,7 @@ EDOC
                       :frameborder => params[:frameborder] || "0"
                       }
               <<EDOC
-<iframe class="#{opts[:class]}" id="#{opts[:id]}" type="text/html" width="#{opts[:width]}" height="#{opts[:height]}" src="http://www.youtube.com/embed/#{unique_id}" frameborder="#{opts[:frameborder]}">
+<iframe class="#{opts[:class]}" id="#{opts[:id]}" type="text/html" width="#{opts[:width]}" height="#{opts[:height]}" src="http://www.youtube.com/embed/#{unique_id}" frameborder="#{opts[:frameborder]}"></iframe>
 EDOC
             end
 

--- a/test/test_video.rb
+++ b/test/test_video.rb
@@ -39,5 +39,10 @@ class TestVideo < Test::Unit::TestCase
     video = YouTubeIt::Model::Video.new(:video_id => "tag:youtube.com,2008:video:EkF4JD2rO3Q", :player_url=>"http://www.youtube.com/v/EkF4JD2rO3Q&feature=youtube_gdata_player", :widescreen => true)
     assert_equal "<object width=\"1280\" height=\"745\">\n<param name=\"movie\" value=\"http://www.youtube.com/v/EkF4JD2rO3Q&feature=youtube_gdata_player\"></param>\n<param name=\"wmode\" value=\"transparent\"></param>\n<embed src=\"http://www.youtube.com/v/EkF4JD2rO3Q&feature=youtube_gdata_player\" type=\"application/x-shockwave-flash\"\nwmode=\"transparent\" width=\"1280\" height=\"745\"></embed>\n</object>\n", video.embed_html_with_width(1280)
   end
+  
+  def test_should_have_iframe_close_tag
+    video = YouTubeIt::Model::Video.new(:video_id => "tag:youtube.com,2008:video:EkF4JD2rO3Q")
+    assert_equal "<iframe class=\"\" id=\"\" type=\"text/html\" width=\"425\" height=\"350\" src=\"http://www.youtube.com/embed/EkF4JD2rO3Q\" frameborder=\"0\"></iframe>\n", video.embed_html5
+  end
 end
 


### PR DESCRIPTION
I found a tiny bug and fixed it:
Video#embed_html5 doesn't output </iframe> - close tag -
