### PR TITLE
fix vid_regex for video_id that includes hyphen

### DIFF
--- a/lib/youtube_it/client.rb
+++ b/lib/youtube_it/client.rb
@@ -85,7 +85,7 @@ class YouTubeIt
     # YouTubeIt::Model::Video
     def video_by(video)
       vid = nil
-      vid_regex = /(?:youtube.com|youtu.be).*(?:\/|v=)(\w+)/
+      vid_regex = /(?:youtube.com|youtu.be).*(?:\/|v=)([\w-]+)/
       if video =~ vid_regex
         vid = $1
       else


### PR DESCRIPTION
video_id sometimes includes hyphen like this: http://youtu.be/63ASo-iq6aw
