### PR TITLE
Making Faraday adapter configurable

### DIFF
--- a/lib/youtube_it.rb
+++ b/lib/youtube_it.rb
@@ -33,6 +33,14 @@ class YouTubeIt
     @logger ||= create_default_logger
   end
 
+  def self.adapter=(faraday_adapter)
+    @adapter = faraday_adapter
+  end
+  
+  def self.adapter
+    @adapter ||= Faraday.default_adapter
+  end
+  
   # Gets mixed into the classes to provide the logger method
   module Logging #:nodoc:
 

--- a/lib/youtube_it/request/video_upload.rb
+++ b/lib/youtube_it/request/video_upload.rb
@@ -524,7 +524,7 @@ class YouTubeIt
           builder.use Faraday::Request::OAuth, @config_token if @config_token
           builder.use Faraday::Request::AuthHeader, authorization_headers
           builder.use Faraday::Response::YouTubeIt 
-          builder.adapter Faraday.default_adapter 
+          builder.adapter YouTubeIt.adapter
           
         end
       end

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -359,7 +359,13 @@ class TestClient < Test::Unit::TestCase
     video = @client.video_by("https://www.youtube.com/watch?v=EkF4JD2rO3Q")
     assert_valid_video video
   end
-
+  
+  def test_configure_faraday_adapter
+    assert YouTubeIt.adapter == Faraday.default_adapter
+    YouTubeIt.adapter = :net_http
+    assert YouTubeIt.adapter == :net_http
+  end
+  
   private
   
     def assert_valid_video (video)


### PR DESCRIPTION
Does not seem to work when Faraday.default_adapter = :em_synchrony.
This commit adds a way to override Faraday's default_adapter for video uploads
