### PR TITLE
Support for restriction parameter in video search

### DIFF
--- a/lib/youtube_it/request/video_search.rb
+++ b/lib/youtube_it/request/video_search.rb
@@ -17,7 +17,9 @@ class YouTubeIt
       attr_reader :racy                            # racy ([exclude], include)
       attr_reader :author
       attr_reader :lang                            # lt
-
+      attr_reader :restriction
+      
+      
       def initialize(params={})
         # Initialize our various member data to avoid warnings and so we'll
         # automatically fall back to the youtube api defaults
@@ -62,6 +64,7 @@ class YouTubeIt
           'format' => @video_format,
           'racy' => @racy,
           'author' => @author,
+          'restriction' => @restriction,
           'lr' => @lang
         }
       end

--- a/test/test_video_search.rb
+++ b/test/test_video_search.rb
@@ -137,5 +137,11 @@ class TestVideoSearch < Test::Unit::TestCase
     request = YouTubeIt::Request::UserSearch.new(:favorites, :user => 'liz', :offset => 20, :max_results => 10)
     assert_equal "http://gdata.youtube.com/feeds/api/users/liz/favorites?max-results=10&start-index=20&v=2", request.url
   end
-
+  
+  # -- Queries with restrictions ---------------------------------------------------------------------------------
+  
+  def test_should_build_basic_query_url_with_restriction
+    request = YouTubeIt::Request::VideoSearch.new(:query => "penguin", :restriction => "DE")
+    assert_equal "http://gdata.youtube.com/feeds/api/videos?q=penguin&restriction=DE&v=2", request.url
+  end
 end


### PR DESCRIPTION
Support for the restriction parameter in search queries.

http://code.google.com/intl/de-DE/apis/youtube/2.0/reference.html#restrictionsp
