### PR TITLE
Video#unique_id was nil when browsing playlist (fixes #54)

### DIFF
--- a/lib/youtube_it/client.rb
+++ b/lib/youtube_it/client.rb
@@ -411,6 +411,7 @@ class YouTubeIt
       @client_secret        = options[:client_secret]
       @client_access_token  = options[:client_access_token]
       @client_refresh_token = options[:client_refresh_token]
+      @client_token_expires_at = options[:client_token_expires_at]
       @dev_key              = options[:dev_key]
     end
 
@@ -422,7 +423,7 @@ class YouTubeIt
     end
     
     def access_token
-      @access_token ||= ::OAuth2::AccessToken.new(oauth_client, @client_access_token, :refresh_token => @client_refresh_token)
+      @access_token ||= ::OAuth2::AccessToken.new(oauth_client, @client_access_token, :refresh_token => @client_refresh_token, :expires_at => @client_token_expires_at)
     end
 
     def refresh_access_token!

--- a/lib/youtube_it/model/video.rb
+++ b/lib/youtube_it/model/video.rb
@@ -149,7 +149,7 @@ class YouTubeIt
       # === Returns
       #   String: The Youtube video id.
       def unique_id
-        video_id[/videos\/([^<]+)/, 1] || video_id[/video\:([^<]+)/, 1]
+        @unique_id || video_id[/videos\/([^<]+)/, 1] || video_id[/video\:([^<]+)/, 1]
       end
 
       # Allows you to check whether the video can be embedded on a webpage.

--- a/lib/youtube_it/parser.rb
+++ b/lib/youtube_it/parser.rb
@@ -374,6 +374,11 @@ class YouTubeIt
         end
         media_group = entry.elements["media:group"]
 
+        ytid = nil
+        unless media_group.elements["yt:videoid"].nil?
+          ytid = media_group.elements["yt:videoid"].text
+        end        
+
         # if content is not available on certain region, there is no media:description, media:player or yt:duration
         description = ""
         unless media_group.elements["media:description"].nil?
@@ -482,7 +487,8 @@ class YouTubeIt
           :position       => position,
           :latitude       => latitude,
           :longitude      => longitude,
-          :state          => state)
+          :state          => state,
+          :unique_id      => ytid)
       end
 
       def parse_media_content (media_content_element)

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -252,6 +252,16 @@ class TestClient < Test::Unit::TestCase
     assert @client.delete_video_from_playlist(playlist.playlist_id, video[:playlist_entry_id])
     assert @client.delete_playlist(playlist.playlist_id)
   end
+
+  def test_should_return_unique_id_from_playlist
+    playlist = @client.add_playlist(:title => "youtube_it test!", :description => "test playlist")
+    video = @client.add_video_to_playlist(playlist.playlist_id,"CE62FSEoY28")
+
+    assert_equal "CE62FSEoY28", playlist.videos.last.unique_id
+
+    assert @client.delete_video_from_playlist(playlist.playlist_id, video[:playlist_entry_id])
+    assert @client.delete_playlist(playlist.playlist_id)
+  end
   
   def test_should_add_and_delete_new_playlist
     result = @client.add_playlist(:title => "youtube_it test4!", :description => "test playlist")


### PR DESCRIPTION
Video#unique_id is nil when browsing playlist. Problem occurs because #video_id doesn't carry information on #unique_id. On the other hand, #unique_id is present in XML returned by YouTube API in yt:id tag in media:groupt

``` ruby
> client = YouTubeIt::Client.new
> client.playlist("21C62A3473376C47").videos[0].video_id
 => "tag:youtube.com,2008:playlist:21C62A3473376C47:PLyiwTzVYoxrm7UlMB2jGbokLoGU0nnBox"  # no unique_id here
> client.playlist("21C62A3473376C47").videos[0].player_url
 => "http://www.youtube.com/watch?v=aWEghdiY9cs&feature=youtube_gdata_player" 
> client.playlist("21C62A3473376C47").videos[0].unique_id
 => nil # returned, expected: aWEghdiY9cs
```

Now unique_id will be fetched from feed `<media:group><yt:id>` if present.
