### PR TITLE
Add support for Insight URIs, if present in user/video responses

### DIFF
--- a/lib/youtube_it/model/user.rb
+++ b/lib/youtube_it/model/user.rb
@@ -22,6 +22,7 @@ class YouTubeIt
       attr_reader :videos_watched
       attr_reader :view_count
       attr_reader :avatar
+      attr_reader :insight_uri
     end
   end
 end

--- a/lib/youtube_it/model/video.rb
+++ b/lib/youtube_it/model/video.rb
@@ -118,6 +118,9 @@ class YouTubeIt
       # *String*:: State of the video (processing, restricted, deleted, rejected and failed)
       attr_reader :state
 
+      # *String*:: URI for insight for this video, if present; nil otherwise
+      attr_reader :insight_uri
+
 
       # Geodata
       attr_reader :where

--- a/lib/youtube_it/parser.rb
+++ b/lib/youtube_it/parser.rb
@@ -298,7 +298,8 @@ class YouTubeIt
           :subscribers    => entry.elements["yt:statistics"].attributes["subscriberCount"],
           :videos_watched => entry.elements["yt:statistics"].attributes["videoWatchCount"],
           :view_count     => entry.elements["yt:statistics"].attributes["viewCount"],
-          :upload_views   => entry.elements["yt:statistics"].attributes["totalUploadViews"]
+          :upload_views   => entry.elements["yt:statistics"].attributes["totalUploadViews"],
+          :insight_uri    => (entry.elements['link[attribute::rel="http://gdata.youtube.com/schemas/2007#insight.views"]'].attributes['href'] rescue nil)
         )
       end
     end
@@ -463,6 +464,8 @@ class YouTubeIt
           
         end
 
+        insight_uri = (entry.elements['link[attribute::rel="http://gdata.youtube.com/schemas/2007#insight.views"]'].attributes['href'] rescue nil)
+
         YouTubeIt::Model::Video.new(
           :video_id       => video_id,
           :published_at   => published_at,
@@ -488,6 +491,7 @@ class YouTubeIt
           :latitude       => latitude,
           :longitude      => longitude,
           :state          => state,
+          :insight_uri    => insight_uri,
           :unique_id      => ytid)
       end
 

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -298,6 +298,8 @@ class TestClient < Test::Unit::TestCase
    assert_valid_video video
    result = @client.my_videos
    assert_equal result.videos.first.unique_id, video.unique_id
+   assert_not_nil result.videos.first.insight_uri, 'insight data not present'
+  ensure
    @client.video_delete(video.unique_id)
   end
   
@@ -347,7 +349,8 @@ class TestClient < Test::Unit::TestCase
      
   def test_should_get_profile
     profile = @client.profile
-    assert_equal profile.username, "tubeit20101" 
+    assert_equal profile.username, "tubeit20101"
+    assert_not_nil profile.insight_uri, 'user insight_uri nil'
   end
   
   def test_should_add_and_delete_video_to_favorite


### PR DESCRIPTION
While actually adding support for [Insight Data](http://code.google.com/apis/youtube/2.0/developers_guide_protocol_insight.html) would be well outside the scope of this project (CSV's in a zip file: wheee), we can at least make the URI to this resource available pretty trivially.
