### PR TITLE
Remove the where attribute from the Video model

### DIFF
--- a/lib/youtube_it/model/video.rb
+++ b/lib/youtube_it/model/video.rb
@@ -120,7 +120,6 @@ class YouTubeIt
 
 
       # Geodata
-      attr_reader :where
       attr_reader :position
       attr_reader :latitude
       attr_reader :longitude

--- a/lib/youtube_it/parser.rb
+++ b/lib/youtube_it/parser.rb
@@ -483,7 +483,6 @@ class YouTubeIt
           :widescreen     => widescreen,
           :noembed        => noembed,
           :racy           => racy,
-          :where          => where,
           :position       => position,
           :latitude       => latitude,
           :longitude      => longitude,


### PR DESCRIPTION
In an attempt to cache my YouTube API responses in production, I ran into the issue of `YouTubeIt::Model::Video` objects not being serializable when they contain geo-rss data.

The where attribute is the problematic one (an instance of `REXML::Element`). With position, latitude, and longitude available, this property is redundant so I removed it.
