### PR TITLE
properly encode ampersand in video search

### DIFF
--- a/lib/youtube_it.rb
+++ b/lib/youtube_it.rb
@@ -19,8 +19,7 @@ class YouTubeIt
   end
 
   def self.esc(s) #:nodoc:
-    # URI encodes correctly Unicode characters
-    URI.encode(s.to_s.tr(' ','+'))
+    CGI.escape(s.to_s)
   end
 
   # Set the logger for the library

--- a/lib/youtube_it/client.rb
+++ b/lib/youtube_it/client.rb
@@ -242,6 +242,11 @@ class YouTubeIt
     def my_messages(opts = {})
       client.get_my_messages(opts)
     end
+    
+    # Gets the user's watch history
+    def watch_history
+      client.get_watch_history
+    end
 
     private
 

--- a/lib/youtube_it/client.rb
+++ b/lib/youtube_it/client.rb
@@ -413,6 +413,7 @@ class YouTubeIt
       @client_refresh_token    = options[:client_refresh_token]
       @client_token_expires_at = options[:client_token_expires_at]
       @dev_key                 = options[:dev_key]
+      @legacy_debug_flag       = options[:debug]
     end
 
     def oauth_client

--- a/lib/youtube_it/client.rb
+++ b/lib/youtube_it/client.rb
@@ -228,17 +228,17 @@ class YouTubeIt
       client.get_my_videos(opts)
     end
     
-    # Get's all of the user's contacts/friends. 
+    # Gets all of the user's contacts/friends. 
     def my_contacts(opts = {})
       client.get_my_contacts(opts)
     end
     
-    # Send vedio message
+    # Send video message
     def send_message(opts = {})
       client.send_message(opts)
     end
     
-    # Get's all of the user's messages/inbox. 
+    # Gets all of the user's messages/inbox. 
     def my_messages(opts = {})
       client.get_my_messages(opts)
     end

--- a/lib/youtube_it/request/base_search.rb
+++ b/lib/youtube_it/request/base_search.rb
@@ -52,6 +52,10 @@ class YouTubeIt
         if fields[:view_count]
           fields_param << "entry[yt:statistics/@viewCount > #{fields[:view_count]}]"
         end
+        
+        if fields[:entry]
+          fields_param << "entry[#{fields[:entry]}]"
+        end
 
 
         return "&fields=#{URI.escape(fields_param.join(","))}"

--- a/lib/youtube_it/request/video_upload.rb
+++ b/lib/youtube_it/request/video_upload.rb
@@ -348,6 +348,13 @@ class YouTubeIt
          
         return {:code => response.status, :body => response.body}
       end
+      
+      def get_watch_history
+        watch_history_url = "/feeds/api/users/default/watch_history?v=2"
+        response = yt_session.get(watch_history_url)
+        
+        return YouTubeIt::Parser::VideosFeedParser.new(response.body).parse
+      end
 
 
       private

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -290,7 +290,7 @@ class TestClient < Test::Unit::TestCase
   end
   
   def test_get_current_user
-   assert_equal @client.current_user, 'tubeit20101'
+   assert_equal 'tubeit20101', @client.current_user
   end
   
   def test_should_get_my_videos
@@ -347,7 +347,7 @@ class TestClient < Test::Unit::TestCase
      
   def test_should_get_profile
     profile = @client.profile
-    assert_equal profile.username, "tubeit20101" 
+    assert_equal "tubeit20101", profile.username
   end
   
   def test_should_add_and_delete_video_to_favorite

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -363,6 +363,11 @@ class TestClient < Test::Unit::TestCase
     assert_equal "%D1%81%D0%BF%D1%8F%D1%82+%D1%83%D1%81%D1%82%D0%B0%D0%BB%D1%8B%D0%B5+%D0%B8%D0%B3%D1%80%D1%83%D1%88%D0%BA%D0%B8", result
   end
   
+  def test_should_encode_ampersand
+    result = YouTubeIt.esc("such & such")
+    assert_equal "such+%26+such", result
+  end
+  
   def test_unicode_query
     videos = @client.videos_by(:query => 'спят усталые игрушки').videos
     assert videos.map(&:unique_id).include?("w-7BT2CFYNU")

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -279,7 +279,7 @@ class TestClient < Test::Unit::TestCase
     
   def test_should_list_playlist_for_user
     result = @client.playlists('chebyte')
-    assert result.last.title, "rock"
+    assert_equal "rock", result.last.title
   end
     
   def test_should_determine_if_widescreen_video_is_widescreen
@@ -360,7 +360,7 @@ class TestClient < Test::Unit::TestCase
   
   def test_esc
     result = YouTubeIt.esc("спят усталые игрушки")
-    assert result, "спят+усталые+игрушки"
+    assert_equal "%D1%81%D0%BF%D1%8F%D1%82+%D1%83%D1%81%D1%82%D0%B0%D0%BB%D1%8B%D0%B5+%D0%B8%D0%B3%D1%80%D1%83%D1%88%D0%BA%D0%B8", result
   end
   
   def test_unicode_query


### PR DESCRIPTION
if you search for something with an ampersand it won't encode the character properly. This is because it's using URI.encode not CGI.escape. See http://bugs.ruby-lang.org/issues/1680

`URI.encode` :

```
001:0> YouTubeIt::Client.new(:debug => true).videos_by(:query => "Stephen Malkmus & The Jicks Fall Away").videos[0].title
Submitting request [url=http://gdata.youtube.com/feeds/api/videos?max-results=25&q=Stephen+Malkmus+&+The+Jicks+Fall+Away&start-index=1&v=2].
=> "Stephen Malkmus and The Jicks - \"Senator\""
```

`CGI.escape` :

```
007:0> YouTubeIt::Client.new(:debug => true).videos_by(:query => "Stephen Malkmus & The Jicks Fall Away").videos[0].title
Submitting request [url=http://gdata.youtube.com/feeds/api/videos?max-results=25&q=Stephen+Malkmus+%26+The+Jicks+Fall+Away&start-index=1&v=2].
=> "Stephen Malkmus & the Jicks - Fall Away"
```

(I also fixed some of the other tests)
