### PR TITLE
OAuth2Client#refresh_access_token! should cause new client to be created

### DIFF
--- a/lib/youtube_it/client.rb
+++ b/lib/youtube_it/client.rb
@@ -438,7 +438,13 @@ class YouTubeIt
     end
 
     def refresh_access_token!
-      @access_token = access_token.refresh!
+      new_access_token = access_token.refresh!
+      require 'thread' unless Thread.respond_to?(:exclusive)
+      Thread.exclusive do
+        @access_token = new_access_token
+        @client = nil
+      end
+      @access_token
     end
 
     def current_user


### PR DESCRIPTION
OAuth2Client#client continues to reference original token, even after refreshing. This patch deletes the cached `@client` so it will be regenerated on next request.

Note: Destructive action is wrapped in a Thread.exclusive to make the action thread-safe.
