### PR TITLE
add support for getting multiple profiles in batch

### DIFF
--- a/lib/youtube_it/client.rb
+++ b/lib/youtube_it/client.rb
@@ -148,6 +148,10 @@ class YouTubeIt
     def profile(user = nil)
       client.profile(user)
     end
+
+    def profiles(*users)
+      client.profiles(*users)
+    end
     
     # Fetches a user's activity feed.
     def activity(user = nil, opts = {})

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -383,6 +383,26 @@ class TestClient < Test::Unit::TestCase
     assert_equal profile.username, "tubeit20101"
     assert_not_nil profile.insight_uri, 'user insight_uri nil'
   end
+
+  def test_should_get_another_profile
+    profile = @client.profile('honda')
+    assert_equal profile.username, "honda"
+    assert_nil profile.insight_uri, 'DANGER: user insight_uri not nil for unauthed user; leaking private data?'
+  end
+
+  def test_should_get_multi_profiles
+    profiles = @client.profiles ['tubeit20101', 'honda','some_non-existing_username'] 
+    assert_operator profiles, :has_key?, 'tubeit20101'
+    assert_equal profiles['tubeit20101'].username, "tubeit20101"
+    assert_not_nil profiles['tubeit20101'].insight_uri, 'user insight_uri nil for authed user'
+    
+    assert_operator profiles, :has_key?, 'honda'
+    assert_equal profiles['honda'].username, "honda"
+    assert_nil profiles['honda'].insight_uri, 'DANGER: user insight_uri not nil for unauthed user; leaking private data?'
+
+    assert_operator profiles, :has_key?, 'some_non-existing_username'
+    assert_nil profiles['some_non-existing_username']
+  end
   
   def test_should_add_and_delete_video_to_favorite
     video_id ="j5raG94IGCc"


### PR DESCRIPTION
api is this:

``` ruby
profiles = youtube_client.profiles(['some_existing_username','not_exist']) 
pp profiles.inspect 
# {
#    "not_exist"=>nil,
#    "some_existing_username" => <YouTubeIt::Model::User:0xe45d3b @username="some_existing_username" ... >
# }
```

Reuses existing user parser, supports any number of users, breaking into blocks of 50 per request to handle api limitations.

TODO: Add in better why-did-it-fail-to-get-a-certain-user support instead of just returning nil
