### PR TITLE
OAuth2Client refresh token is blank when refreshing

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -52,7 +52,7 @@ Client with OAuth:
   $ client.authorize_from_access("access_token", "access_secret")
 
 Client with OAuth2:
-  $ client = YouTubeIt::OAuth2Client.new(client_access_token: "access_token", client_refresh_token: "refresh_token", client_id: "client_id", client_secret: "client_secret", dev_key: "dev_key", expires_at: "expiration time")
+  $ client = YouTubeIt::OAuth2Client.new(client_access_token: "access_token", client_refresh_token: "refresh_token", client_id: "client_id", client_secret: "client_secret", dev_key: "dev_key", client_token_expires_at: "expiration time")
 
 If your access token is still valid (be careful, access tokens may only be valid for about 1 hour), you can use the client directly. If you want to refresh the access token using the refresh token just do:
 


### PR DESCRIPTION
Hello,
I'm using something like this:

``` ruby
      ::YouTubeIt::OAuth2Client.new({
        client_token_expires_at: @youtube_credentials.expires_at,
        client_access_token:     @youtube_credentials.token,
        client_refresh_token:    @youtube_credentials.refresh_token,
        client_id:               Settings.services.youtube.client_key,
        client_secret:           Settings.services.youtube.client_secret,
        dev_key:                 Settings.services.youtube.developer_key,
      })
```

I save this data in order to properly refresh the token when it does expire (it does so by raising a OAuth2::Error).

It should be noted that I'm using `client_token_expires_at` because I think that the proposed `expires_at` in readme is wrong, this pull request should fix this.

When I refresh the token through `client.refresh_access_token!` what I have back is an instance of `OAuth2::AccessToken` which does indeed contain a new `token` but the `refresh_token` is nil.

I need the refresh_token stored somewhere in order to refresh the old one at the next authentication error.
I'm still not sure if this AccessToken should carry the refresh_token but I can't see other ways to perform a refresh afterwards.

Thanks.

```
[1] pry(#<OAuth2::AccessToken>)> ls
OAuth2::AccessToken#methods: []  client  delete  expired?  expires?  expires_at  expires_in  get  options  options=  params  post  put  refresh!  refresh_token  request  token
self.methods: __binding_impl__
instance variables: @client  @expires_at  @expires_in  @options  @params  @refresh_token  @token
locals: _  _dir_  _ex_  _file_  _in_  _out_  _pry_
[2] pry(#<OAuth2::AccessToken>)> expired?
=> false
[3] pry(#<OAuth2::AccessToken>)> expires?
=> true
[4] pry(#<OAuth2::AccessToken>)> expires_in
=> 3600
[5] pry(#<OAuth2::AccessToken>)> refresh_token
=> nil
[10] pry(#<OAuth2::AccessToken>)> refresh!
RuntimeError: A refresh_token is not available
```
