### PR TITLE
Private & AccessControls

### DIFF
--- a/lib/youtube_it/model/video.rb
+++ b/lib/youtube_it/model/video.rb
@@ -121,6 +121,11 @@ class YouTubeIt
       # *String*:: URI for insight for this video, if present; nil otherwise
       attr_reader :insight_uri
 
+      # *Boolean*:: Whether or not a video is private. Non-standard name to avoid collision with Rubys own 'private' stuff.
+      attr_reader :perm_private
+ 
+      # *Hash*:: List of access controls
+      attr_reader :accessControls
 
       # Geodata
       attr_reader :position

--- a/lib/youtube_it/parser.rb
+++ b/lib/youtube_it/parser.rb
@@ -466,6 +466,13 @@ class YouTubeIt
 
         insight_uri = (entry.elements['link[attribute::rel="http://gdata.youtube.com/schemas/2007#insight.views"]'].attributes['href'] rescue nil)
 
+        perm_private = media_group.elements["yt:private"] ? true : false
+
+        accessControls = {}
+        accessControl = entry.elements.each("yt:accessControl") do |accessControl|
+          accessControls[accessControl.attributes["action"]] = accessControl.attributes["permission"]
+        end
+
         YouTubeIt::Model::Video.new(
           :video_id       => video_id,
           :published_at   => published_at,
@@ -491,7 +498,9 @@ class YouTubeIt
           :longitude      => longitude,
           :state          => state,
           :insight_uri    => insight_uri,
-          :unique_id      => ytid)
+          :unique_id      => ytid,
+          :perm_private   => perm_private,
+          :accessControls => accessControls)
       end
 
       def parse_media_content (media_content_element)


### PR DESCRIPTION
I added parsing of yt:private and the accessControls stuff to the parser and put it in the corresponding new fields in the video model. The yt:private is stored in perm_private, making it a little nonstandard. However, I wanted to avoid any mixups with the built-in Ruby private? method.
