### PR TITLE
Update youtube_it.gemspec

### DIFF
--- a/youtube_it.gemspec
+++ b/youtube_it.gemspec
@@ -86,7 +86,7 @@ Gem::Specification.new do |s|
     end
   else
     s.add_dependency(%q<oauth>, ["~> 0.4.4"])
-    s.add_dependency(%q<oauth2>, ["~> 0.5.2"])
+    s.add_dependency(%q<oauth2>, ["~> 0.6.0"])
     s.add_dependency(%q<simple_oauth>, ["~> 0.1.5"])
     s.add_dependency(%q<faraday>, ["~> 0.7.3"])
     s.add_dependency(%q<builder>, [">= 0"])


### PR DESCRIPTION
Bump oauth2 to 0.6.0:

```
Bundler could not find compatible versions for gem "oauth2":
  In Gemfile:
    youtube_it (>= 0) ruby depends on
      oauth2 (~> 0.5.2) ruby

    oauth2 (0.6.0)
```
