### PR TITLE
published date not always set

### DIFF
--- a/lib/youtube_it/model/playlist.rb
+++ b/lib/youtube_it/model/playlist.rb
@@ -2,8 +2,9 @@ class YouTubeIt
   module Model
     class Playlist < YouTubeIt::Record
       attr_reader :title, :description, :summary, :playlist_id, :xml, :published, :response_code
-      def videos
-        YouTubeIt::Parser::VideosFeedParser.new("http://gdata.youtube.com/feeds/api/playlists/#{playlist_id}?v=2").parse_videos
+      def videos(order_by = :position)
+        playlist_url = "/feeds/api/playlists/%s?v=2&orderby=%s" % [playlist_id, order_by]
+        YouTubeIt::Parser::VideosFeedParser.new("http://gdata.youtube.com/#{playlist_url}").parse_videos
       end
     end
   end

--- a/lib/youtube_it/parser.rb
+++ b/lib/youtube_it/parser.rb
@@ -341,7 +341,9 @@ class YouTubeIt
       protected
       def parse_entry(entry)
         video_id = entry.elements["id"].text
-        published_at  = entry.elements["published"] ? Time.parse(entry.elements["published"].text) : nil
+        published_at  = entry.elements["published"] ? Time.parse(entry.elements["published"].text) :
+          entry.elements["media:group"].elements["yt:uploaded"] ? Time.parse(entry.elements["media:group"].elements["yt:uploaded"].text) :
+          nil
         updated_at    = entry.elements["updated"] ? Time.parse(entry.elements["updated"].text) : nil
 
         # parse the category and keyword lists

--- a/test/files/youtube_video_response_without_published.xml
+++ b/test/files/youtube_video_response_without_published.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/" xmlns:gd="http://schemas.google.com/g/2005" xmlns:yt="http://gdata.youtube.com/schemas/2007" gd:etag="W/&quot;A0UBR347eCp7ImA9Wx9bFEs.&quot;">
+	<id>tag:youtube.com,2008:video:AbC123DeFgH</id>
+	<updated>2011-02-23T13:54:16.000Z</updated>
+	<category scheme="http://schemas.google.com/g/2005#kind" term="http://gdata.youtube.com/schemas/2007#video"/>
+	<category scheme="http://gdata.youtube.com/schemas/2007/categories.cat" term="Test" label="Test"/>
+	<category scheme="http://gdata.youtube.com/schemas/2007/keywords.cat" term="test"/>
+	<title>YouTube Test Video</title>
+	<content type="application/x-shockwave-flash" src="http://www.youtube.com/v/YTAbC123DeF?f=videos&amp;app=youtube_gdata"/>
+	<link rel="alternate" type="text/html" href="http://www.youtube.com/watch?v=AbC123DeFgH&amp;feature=youtube_gdata"/>
+	<link rel="http://gdata.youtube.com/schemas/2007#video.responses" type="application/atom+xml" href="http://gdata.youtube.com/feeds/api/videos/AbC123DeFgH/responses?v=2"/>
+	<link rel="http://gdata.youtube.com/schemas/2007#video.related" type="application/atom+xml" href="http://gdata.youtube.com/feeds/api/videos/AbC123DeFgH/related?v=2"/>
+	<link rel="http://gdata.youtube.com/schemas/2007#mobile" type="text/html" href="http://m.youtube.com/details?v=AbC123DeFgH"/>
+	<link rel="self" type="application/atom+xml" href="http://gdata.youtube.com/feeds/api/videos/AbC123DeFgH?v=2"/>
+	<author>
+		<name>Test user</name>
+		<uri>http://gdata.youtube.com/feeds/api/users/test_user</uri>
+	</author>
+	<yt:accessControl action="comment" permission="allowed"/>
+	<yt:accessControl action="commentVote" permission="allowed"/>
+	<yt:accessControl action="videoRespond" permission="moderated"/>
+	<yt:accessControl action="rate" permission="allowed"/>
+	<yt:accessControl action="embed" permission="allowed"/>
+	<yt:accessControl action="list" permission="allowed"/>
+	<yt:accessControl action="syndicate" permission="allowed"/>
+	<gd:comments>
+		<gd:feedLink href="http://gdata.youtube.com/feeds/api/videos/AbC123DeFgH/comments?v=2" countHint="1000"/>
+	</gd:comments>
+	<media:group>
+		<media:category label="Sports" scheme="http://gdata.youtube.com/schemas/2007/categories.cat">Test</media:category>
+		<media:content url="http://www.youtube.com/v/AbC123DeFgH?f=videos&amp;app=youtube_gdata" type="application/x-shockwave-flash" medium="video" isDefault="true" expression="full" duration="356" yt:format="5"/>
+		<media:content url="rtsp://v7.cache6.c.youtube.com/TESTCACHE/0/0/0/video.3gp" type="video/3gpp" medium="video" expression="full" duration="356" yt:format="1"/>
+		<media:content url="rtsp://v8.cache7.c.youtube.com/TESTCACHE/0/0/0/video.3gp" type="video/3gpp" medium="video" expression="full" duration="356" yt:format="6"/>
+		<media:credit role="uploader" scheme="urn:youtube" yt:type="partner">Test user</media:credit>
+		<media:description type="plain">Youtube Test Video</media:description>
+		<media:keywords>Test, Youtube, Youtube_it, Ruby</media:keywords>
+		<media:player url="http://www.youtube.com/watch?v=AbC123DeFgH&amp;feature=youtube_gdata_player"/>
+		<media:thumbnail url="http://i.ytimg.com/vi/AbC123DeFgH/default.jpg" height="90" width="120" time="00:02:58" yt:name="default"/>
+		<media:thumbnail url="http://i.ytimg.com/vi/AbC123DeFgH/hqdefault.jpg" height="360" width="480" yt:name="hqdefault"/>
+		<media:thumbnail url="http://i.ytimg.com/vi/AbC123DeFgH/1.jpg" height="90" width="120" time="00:01:29" yt:name="start"/>
+		<media:thumbnail url="http://i.ytimg.com/vi/AbC123DeFgH/2.jpg" height="90" width="120" time="00:02:58" yt:name="middle"/>
+		<media:thumbnail url="http://i.ytimg.com/vi/AbC123DeFgH/3.jpg" height="90" width="120" time="00:04:27" yt:name="end"/>
+		<media:title type="plain">Ich sterbe für YouTube</media:title>
+		<yt:aspectRatio>widescreen</yt:aspectRatio>
+		<yt:duration seconds="356"/>
+		<yt:uploaded>2010-12-29T13:57:49.000Z</yt:uploaded>
+		<yt:videoid>AbC123DeFgH</yt:videoid>
+	</media:group>
+	<gd:rating average="4.305027" max="5" min="1" numRaters="2049" rel="http://schemas.google.com/g/2005#overall"/>
+	<yt:statistics favoriteCount="200" viewCount="240000"/>
+	<yt:rating numDislikes="350" numLikes="1700"/>
+</entry>

--- a/test/test_video_feed_parser.rb
+++ b/test/test_video_feed_parser.rb
@@ -61,6 +61,13 @@ class TestVideoFeedParser < Test::Unit::TestCase
       assert_equal Time.parse("Wed Dec 29 13:57:49 UTC 2010"), video.published_at
     end
   end
+  
+  def test_should_parse_uploaded_as_published_at_correctly
+    with_video_response("/files/youtube_video_response_without_published.xml") do |parser|
+      video = parser.parse
+      assert_equal Time.parse("Wed Dec 29 13:57:49 UTC 2010"), video.published_at
+    end
+  end
 
   def test_should_parse_updated_at_correctly
     with_video_response do |parser|
@@ -254,8 +261,8 @@ class TestVideoFeedParser < Test::Unit::TestCase
     end
   end
 
-  def with_video_response &block
-    File.open(File.dirname(__FILE__) + '/files/youtube_video_response.xml') do |xml|
+  def with_video_response(file = "/files/youtube_video_response.xml", &block)
+    File.open(File.dirname(__FILE__) + file) do |xml|
       parser = YouTubeIt::Parser::VideoFeedParser.new xml.read
       yield parser
     end


### PR DESCRIPTION
The <published> tag is sometimes missing within the "feed", then try to
use yt:uploaded within media:group.
