### PR TITLE
add_comment method now returns parsed comment from API (with youtube unique_id)

### DIFF
--- a/lib/youtube_it/parser.rb
+++ b/lib/youtube_it/parser.rb
@@ -17,6 +17,11 @@ class YouTubeIt
         parse_content @content
       end
 
+      def parse_single_entry
+        doc = Nokogiri::XML(@content)
+        parse_entry(doc.at("entry") || doc)
+      end
+
       def parse_videos
         doc = Nokogiri::XML(@content)
         videos = []

--- a/lib/youtube_it/request/video_upload.rb
+++ b/lib/youtube_it/request/video_upload.rb
@@ -195,8 +195,8 @@ class YouTubeIt
         comment_body = comment_xml_for(:comment => comment, :reply_to => reply_to_url(video_id, reply_to))
         comment_url  = "/feeds/api/videos/%s/comments" % video_id
         response     = yt_session.post(comment_url, comment_body)
-
-        return {:code => response.status, :body => response.body}
+        comment = YouTubeIt::Parser::CommentsFeedParser.new(response.body).parse_single_entry
+        return {:code => response.status, :body => response.body, :comment => comment}
       end
 
       def delete_comment(video_id, comment_id)


### PR DESCRIPTION
Totally backward compatible, only adding a new value to the returned hash.
