### PR TITLE
Adding support for yt:recorded

### DIFF
--- a/lib/youtube_it/model/video.rb
+++ b/lib/youtube_it/model/video.rb
@@ -82,6 +82,9 @@ class YouTubeIt
       # *Time*:: When the video's was uploaded.
       attr_reader :uploaded_at
 
+      # *Time*:: When the video's was recorded.
+      attr_reader :recorded_at
+
       # *Array*:: A array of YouTubeIt::Model::Category objects that describe the videos categories.
       attr_reader :categories
 

--- a/lib/youtube_it/parser.rb
+++ b/lib/youtube_it/parser.rb
@@ -381,6 +381,7 @@ class YouTubeIt
         published_at = entry.at("published") ? Time.parse(entry.at("published").text) : nil
         uploaded_at = entry.at_xpath("media:group/yt:uploaded") ? Time.parse(entry.at_xpath("media:group/yt:uploaded").text) : nil
         updated_at = entry.at("updated") ? Time.parse(entry.at("updated").text) : nil
+        recorded_at = entry.at_xpath("yt:recorded") ? Time.parse(entry.at_xpath("yt:recorded").text) : nil
 
         # parse the category and keyword lists
         categories = []
@@ -520,6 +521,7 @@ class YouTubeIt
           :published_at   => published_at,
           :updated_at     => updated_at,
           :uploaded_at    => uploaded_at,
+          :recorded_at    => recorded_at,
           :categories     => categories,
           :keywords       => keywords,
           :title          => title,


### PR DESCRIPTION
An entry contains a yt:recorded element if a recorded on date has been set by the user. This commit makes this accessible on Video (recorded_at).
