### PR TITLE
Few small fixes in: playlist, documentation and connecting to OAuth2

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -208,7 +208,7 @@ Add Video To Playlist:
   $ client.add_video_to_playlist(playlist_id, video_id)
 
 Remove Video From Playlist:
-  $ client.remove_video_from_playlist(playlist_id, playlist_entry_id)
+  $ client.delete_video_from_playlist(playlist_id, playlist_entry_id)
 
 Select All Videos From your Watch Later Playlist:
   $ watcher_later = client.watcherlater(user) #default: current user
@@ -218,7 +218,7 @@ Add Video To Watcher Later Playlist:
   $ client.add_video_to_watchlater(video_id)
 
 Remove Video From Watch Later Playlist:
-  $ client.remove_video_from_watchlater(watchlater_entry_id)
+  $ client.delete_video_from_watchlater(watchlater_entry_id)
 
 
 List Related Videos

--- a/lib/youtube_it/client.rb
+++ b/lib/youtube_it/client.rb
@@ -444,13 +444,15 @@ class YouTubeIt
       @client_token_expires_at = options[:client_token_expires_at]
       @dev_key                 = options[:dev_key]
       @legacy_debug_flag       = options[:debug]
+      @connection_opts         = options[:connection_opts]   
     end
 
     def oauth_client
       @oauth_client ||= ::OAuth2::Client.new(@client_id, @client_secret,
                                              :site => "https://accounts.google.com",
                                              :authorize_url => '/o/oauth2/auth',
-                                             :token_url => '/o/oauth2/token')
+                                             :token_url => '/o/oauth2/token',
+                                             :connection_opts => @connection_opts)
     end
     
     def access_token

--- a/lib/youtube_it/parser.rb
+++ b/lib/youtube_it/parser.rb
@@ -77,7 +77,7 @@ class YouTubeIt
 
       def parse_content(content)
         xml = Nokogiri::XML(content.body)
-        entry = xml.at("entry") || xml.at("feed")
+        entry = xml.at("feed") || xml.at("entry")
         YouTubeIt::Model::Playlist.new(
           :title         => entry.at("title") && entry.at("title").text,
           :summary       => ((entry.at("summary") || entry.at_xpath("media:group").at_xpath("media:description")).text rescue nil),


### PR DESCRIPTION
First one is in Readme.rdoc file which was misspelling function name.
Second is for fetching data from playlist. Since now it is possible to fetch data from playlist when there are videos. Till today it works only without videos.
Third adds possibility to change default connection options for OAuth2 connections.  

client = YouTubeIt::OAuth2Client.new(
          client_access_token: yt_config["access_token"], 
          client_refresh_token: yt_config["refresh_token"], 
          client_id: config[:youtube_client_id], 
          client_secret: config[:youtube_client_secret], 
          dev_key: config[:youtube_dev_key], 
          expires_at: 3600,
          connection_opts: {ssl: {verify: false}}
        )                              

Allows for tricks like this one with {ssl: {verify: false}} 

What do you think about it?
