### PR TITLE
Add in_playlist_id for removing video from playlist

### DIFF
--- a/lib/youtube_it/model/video.rb
+++ b/lib/youtube_it/model/video.rb
@@ -155,6 +155,22 @@ class YouTubeIt
       def responses
         YouTubeIt::Parser::VideosFeedParser.new("http://gdata.youtube.com/feeds/api/videos/#{unique_id}/responses?v=2").parse
       end
+
+
+      # ID of video in playlist listing
+      # Useful if you have to delete this video from a playlist
+      #
+      # === Example
+      #   >> video.in_playlist_id 
+      #   => "PLk3UVPlPEkey09s2W02R48WMDKjvSb6Hq" 
+      #
+      # === Returns
+      #   String the video id
+      #
+      def in_playlist_id
+        @video_id.split(':').last
+      end
+
       # The ID of the video, useful for searching for the video again without having to store it anywhere.
       # A regular query search, with this id will return the same video.
       #

--- a/lib/youtube_it/version.rb
+++ b/lib/youtube_it/version.rb
@@ -1,4 +1,4 @@
 class YouTubeIt
-  VERSION = '2.1.7'
+  VERSION = '2.1.8'
 end
 


### PR DESCRIPTION
Removing video from playlist is done by a DELETE request on the playlist vidéo uri.

The uri is not ending by an index but by the video id related to the playlist. You should pass this id on seconde parameter to delete_video_from_playlist.
