### PR TITLE
mathn compatibility: Explicitly cast into Integers when they are expected for comparisons

### DIFF
--- a/lib/youtube_it/client.rb
+++ b/lib/youtube_it/client.rb
@@ -439,7 +439,7 @@ class YouTubeIt
       profile = access_token.get("http://gdata.youtube.com/feeds/api/users/default")
       response_code = profile.code.to_i
 
-      if response_code/10 == 20 # success
+      if (response_code / 10).to_i == 20 # success
         Nokogiri::XML(profile.body).at("entry/author/name").text
       elsif response_code == 403 || response_code == 401 # auth failure
         raise YouTubeIt::Upload::AuthenticationError.new(profile.inspect, response_code)
@@ -500,7 +500,7 @@ class YouTubeIt
       profile = access_token.get("http://gdata.youtube.com/feeds/api/users/default")
       response_code = profile.status
 
-      if response_code/10 == 20 # success
+      if (response_code / 10).to_i == 20 # success
         Nokogiri::XML(profile.body).at("entry/author/name").text
       elsif response_code == 403 || response_code == 401 # auth failure
         raise YouTubeIt::Upload::AuthenticationError.new(profile.inspect, response_code)

--- a/lib/youtube_it/middleware/faraday_youtubeit.rb
+++ b/lib/youtube_it/middleware/faraday_youtubeit.rb
@@ -23,7 +23,7 @@ module Faraday
       msg = env[:body] ? parse_upload_error_from(env[:body].gsub(/\n/, '')) : ''
       if env[:status] == 403 || env[:status] == 401
         raise ::AuthenticationError.new(msg, env[:status])
-      elsif env[:status] / 10 != 20
+      elsif (env[:status] / 10).to_i != 20
         raise ::UploadError.new(msg, env[:status])
       end
     end

--- a/lib/youtube_it/request/video_upload.rb
+++ b/lib/youtube_it/request/video_upload.rb
@@ -497,18 +497,6 @@ class YouTubeIt
         end
       end
 
-      def raise_on_faulty_response(response)
-        response_code = response.code.to_i
-        msg = parse_upload_error_from(response.body.gsub(/\n/, ''))
-
-        if response_code == 403 || response_code == 401
-        #if response_code / 10 == 40
-          raise AuthenticationError.new(msg, response_code)
-        elsif response_code / 10 != 20 # Response in 20x means success
-          raise UploadError.new(msg, response_code)
-        end
-      end
-
       def uploaded_video_id_from(string)
         xml = Nokogiri::XML(string)
         xml.at("id").text[/videos\/(.+)/, 1]


### PR DESCRIPTION
We started consistently seeing UploadErrors after adding ruby-units to our project.

Turns out that youtube_it defines request success as `response_code / 10 == 20`. mathn (part of the standard library, required by ruby-units) changes Numeric#/ to always return Rationals instead of Integers. E.g. without mathn `201 / 10 # => 20` whereas with mathn `201 / 10 # => (201/10)`.

The attached pull request explicitly casts these into Integers again for the check to continue working. An alternative would be something like `response_code.divmod(20).first == 20`; not sure what's more readable.

I haven't updated the tests as I didn't know whether the mathn dependency would be desirable. Just stick a `require "mathn"` anywhere in the current version and then in my branch to see the before/after.

Note that I've also removed `VideoUpload#raise_on_faulty_response`. It doesn't seem to be used anywhere.
