### PR TITLE
Allow selecting a protocol when embedding html5

### DIFF
--- a/lib/youtube_it/model/video.rb
+++ b/lib/youtube_it/model/video.rb
@@ -250,12 +250,13 @@ EDOC
                       :id     => params[:id]     || "",
                       :width  => params[:width]  || "425",
                       :height => params[:height] || "350",
+                      :protocol => params[:protocol] || "http",
                       :frameborder => params[:frameborder] || "0",
                       :url_params => params[:url_params] || {}
                       }
               url_opts = opts[:url_params].empty? ? "" : "?#{Rack::Utils::build_query(opts[:url_params])}"
               <<EDOC
-<iframe class="#{opts[:class]}" id="#{opts[:id]}" type="text/html" width="#{opts[:width]}" height="#{opts[:height]}" src="http://www.youtube.com/embed/#{unique_id}#{url_opts}" frameborder="#{opts[:frameborder]}"></iframe>
+<iframe class="#{opts[:class]}" id="#{opts[:id]}" type="text/html" width="#{opts[:width]}" height="#{opts[:height]}" src="#{opts[:protocol]}://www.youtube.com/embed/#{unique_id}#{url_opts}" frameborder="#{opts[:frameborder]}"></iframe>
 EDOC
             end
 

--- a/lib/youtube_it/version.rb
+++ b/lib/youtube_it/version.rb
@@ -1,4 +1,4 @@
 class YouTubeIt
-  VERSION = '2.1.8'
+  VERSION = '2.1.9'
 end
 


### PR DESCRIPTION
I have a site running on SSL and to remove the browser warnings on insecure content I've added an option to supply the protocol of the iframe src.

Usage example:

`video.embed_html5(:protocol => 'https', :width => '380', :height => '234')`

The protocol option defaults to 'http'.

Thanks
