### PR TITLE
Faraday::Reqeust::OAuth2 conflicts with other gems using OAuth2.

### DIFF
--- a/lib/youtube_it/middleware/faraday_authheader.rb
+++ b/lib/youtube_it/middleware/faraday_authheader.rb
@@ -1,5 +1,5 @@
-module Faraday
-  class Request::AuthHeader < Faraday::Middleware
+module FaradayMiddleware
+  class YoutubeAuthHeader < Faraday::Middleware
 
     def call(env)
       req_headers = env[:request_headers]

--- a/lib/youtube_it/middleware/faraday_oauth.rb
+++ b/lib/youtube_it/middleware/faraday_oauth.rb
@@ -1,5 +1,5 @@
-module Faraday
-  class Request::OAuth < Faraday::Middleware
+module FaradayMiddleware
+  class YoutubeOAuth < Faraday::Middleware
     dependency 'simple_oauth'
 
     def call(env)

--- a/lib/youtube_it/middleware/faraday_oauth2.rb
+++ b/lib/youtube_it/middleware/faraday_oauth2.rb
@@ -1,5 +1,5 @@
-module Faraday
-  class Request::OAuth2 < Faraday::Middleware
+module FaradayMiddleware
+  class YoutubeOAuth2 < Faraday::Middleware
     def call(env)
       env[:request_headers]['Authorization'] = "Bearer #{@access_token.token}"
 

--- a/lib/youtube_it/request/video_upload.rb
+++ b/lib/youtube_it/request/video_upload.rb
@@ -637,12 +637,12 @@ class YouTubeIt
         Faraday.new(:url => (url ? url : base_url), :ssl => {:verify => false}) do |builder|
           if @access_token
             if @config_token
-              builder.use Faraday::Request::OAuth, @config_token
+              builder.use FaradayMiddleware::YoutubeOAuth, @config_token
             else
-              builder.use Faraday::Request::OAuth2, @access_token
+              builder.use FaradayMiddleware::YoutubeOAuth2, @access_token
             end
           end
-          builder.use Faraday::Request::AuthHeader, authorization_headers
+          builder.use FaradayMiddleware::YoutubeAuthHeader, authorization_headers
           builder.use Faraday::Response::YouTubeIt
           builder.adapter YouTubeIt.adapter
 


### PR DESCRIPTION
When this gem is used in conjuction with other gems that use Faraday::Reqeust::OAuth2, there is potential for conflict.  This gem actually does conflict with the instagram-ruby-gem.  I changed the classes to use the FaradayMiddleware namespace for consistency, and gave them YouTube specific names. 
