### PR TITLE
Accept an options Hash in #playlist

### DIFF
--- a/lib/youtube_it/client.rb
+++ b/lib/youtube_it/client.rb
@@ -178,8 +178,8 @@ class YouTubeIt
       client.delete_video_from_watchlater(video_id)
     end
 
-    def playlist(playlist_id, order_by = :position)
-      client.playlist(playlist_id, order_by)
+    def playlist(playlist_id, opts = {})
+      client.playlist(playlist_id, opts)
     end
 
     def playlists(user = nil, opts = nil)

--- a/lib/youtube_it/request/video_upload.rb
+++ b/lib/youtube_it/request/video_upload.rb
@@ -317,9 +317,12 @@ class YouTubeIt
         return true
       end
 
-      def playlist(playlist_id, order_by = :position)
-        playlist_url = "/feeds/api/playlists/%s?v=2&orderby=%s" % [playlist_id, order_by]
-        response     = yt_session.get(playlist_url)
+      def playlist(playlist_id, opts = {})
+        playlist_url = "/feeds/api/playlists/%s" % playlist_id
+        params = {'v' => 2, 'orderby' => 'position'}
+        params.merge!(opts) if opts
+        playlist_url << "?#{params.collect { |k,v| [k,v].join '=' }.join('&')}"
+        response = yt_session.get(playlist_url)
 
         return YouTubeIt::Parser::PlaylistFeedParser.new(response).parse
       end

--- a/test/cassettes/playlist_with_paging_parameters.yml
+++ b/test/cassettes/playlist_with_paging_parameters.yml
@@ -1,0 +1,890 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://gdata.youtube.com/feeds/api/users/default
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer ya29.AHES6ZRjjO5OHP2P3EfAKE0eTFwG9kSRey4LLw3-QzDCtXM
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - ! '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Gdata-User-Country:
+      - PL
+      Content-Type:
+      - application/atom+xml; charset=UTF-8
+      Expires:
+      - Thu, 07 Feb 2013 12:11:09 GMT
+      Date:
+      - Thu, 07 Feb 2013 12:11:09 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Accept, X-GData-Authorization, GData-Version
+      Gdata-Version:
+      - '1.0'
+      Last-Modified:
+      - Tue, 05 Feb 2013 04:54:15 GMT
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+    body:
+      encoding: US-ASCII
+      string: <?xml version='1.0' encoding='UTF-8'?><entry xmlns='http://www.w3.org/2005/Atom'
+        xmlns:media='http://search.yahoo.com/mrss/' xmlns:gd='http://schemas.google.com/g/2005'
+        xmlns:yt='http://gdata.youtube.com/schemas/2007'><id>http://gdata.youtube.com/feeds/api/users/WWmLvppy3j64IGmA2dpCyw</id><published>2010-07-06T14:59:05.000Z</published><updated>2013-02-05T04:54:15.000Z</updated><category
+        scheme='http://schemas.google.com/g/2005#kind' term='http://gdata.youtube.com/schemas/2007#userProfile'/><title
+        type='text'>tubeit20101</title><content type='text'/><link rel='alternate'
+        type='text/html' href='http://www.youtube.com/channel/UCWWmLvppy3j64IGmA2dpCyw'/><link
+        rel='http://gdata.youtube.com/schemas/2007#insight.views' type='text/html'
+        href='http://insight.youtube.com/video-analytics/csvreports?query=WWmLvppy3j64IGmA2dpCyw&amp;type=u&amp;starttime=1235865600000&amp;endtime=1360108800000&amp;user_starttime=1359504000000&amp;user_endtime=1360108800000&amp;region=world&amp;token=zM4bJxqfMTUAesAhvXYT-GSOFS18MTM2MDI0MDg2OUAxMzYwMjM5MDY5&amp;hl=en_US'/><link
+        rel='self' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/users/WWmLvppy3j64IGmA2dpCyw'/><author><name>tubeit20101</name><uri>http://gdata.youtube.com/feeds/api/users/tubeit20101</uri></author><yt:age>30</yt:age><gd:feedLink
+        rel='http://gdata.youtube.com/schemas/2007#user.subscriptions' href='http://gdata.youtube.com/feeds/api/users/tubeit20101/subscriptions'
+        countHint='0'/><gd:feedLink rel='http://gdata.youtube.com/schemas/2007#user.contacts'
+        href='http://gdata.youtube.com/feeds/api/users/tubeit20101/contacts' countHint='0'/><gd:feedLink
+        rel='http://gdata.youtube.com/schemas/2007#user.inbox' href='http://gdata.youtube.com/feeds/api/users/tubeit20101/inbox'
+        countHint='0'/><gd:feedLink rel='http://gdata.youtube.com/schemas/2007#user.playlists'
+        href='http://gdata.youtube.com/feeds/api/users/tubeit20101/playlists'/><gd:feedLink
+        rel='http://gdata.youtube.com/schemas/2007#user.uploads' href='http://gdata.youtube.com/feeds/api/users/tubeit20101/uploads'
+        countHint='2'/><gd:feedLink rel='http://gdata.youtube.com/schemas/2007#user.newsubscriptionvideos'
+        href='http://gdata.youtube.com/feeds/api/users/tubeit20101/newsubscriptionvideos'/><yt:location>AR</yt:location><yt:maxUploadDuration
+        seconds='930'/><yt:statistics lastWebAccess='1970-01-01T00:00:00.000Z' subscriberCount='0'
+        videoWatchCount='0' viewCount='91' totalUploadViews='0'/><media:thumbnail
+        url='http://s.ytimg.com/yts/img/silhouette250-vflEqxKg9.png'/><yt:username>tubeit20101</yt:username></entry>
+    http_version: 
+  recorded_at: Thu, 07 Feb 2013 12:11:10 GMT
+- request:
+    method: get
+    uri: http://gdata.youtube.com/feeds/api/users/default/playlists?v=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer ya29.AHES6ZRjjO5OHP2P3EfAKE0eTFwG9kSRey4LLw3-QzDCtXM
+      X-Gdata-Client:
+      - youtube_it
+      X-Gdata-Key:
+      - key=AI39si7WuZZxAkYebKSyrlJR7hIFktt6OoPycEOeOT_yHkZgr6QsGbZgmhKvbS4bsSAv0utgrfhNfXQBITu1wX_z3VsZE02giQ
+      Gdata-Version:
+      - '2'
+      Content-Type:
+      - application/atom+xml; charset=UTF-8
+      Content-Length:
+      - '0'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - ! '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Gdata-User-Country:
+      - PL
+      Content-Type:
+      - application/atom+xml; charset=UTF-8; type=feed
+      Expires:
+      - Thu, 07 Feb 2013 12:11:10 GMT
+      Date:
+      - Thu, 07 Feb 2013 12:11:10 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Accept, X-GData-Authorization, GData-Version
+      Gdata-Version:
+      - '2.1'
+      Etag:
+      - W/"A0cDQXw5fSp7I2A9WhBTEk4."
+      Last-Modified:
+      - Thu, 07 Feb 2013 12:11:10 GMT
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+    body:
+      encoding: US-ASCII
+      string: <?xml version='1.0' encoding='UTF-8'?><feed xmlns='http://www.w3.org/2005/Atom'
+        xmlns:openSearch='http://a9.com/-/spec/opensearch/1.1/' xmlns:gd='http://schemas.google.com/g/2005'
+        xmlns:yt='http://gdata.youtube.com/schemas/2007' gd:etag='W/&quot;A0cDQXw5fSp7I2A9WhBTEk4.&quot;'><id>tag:youtube.com,2008:user:tubeit20101:playlists</id><updated>2013-02-07T12:11:10.225Z</updated><category
+        scheme='http://schemas.google.com/g/2005#kind' term='http://gdata.youtube.com/schemas/2007#playlistLink'/><title>Playlists
+        of tubeit20101</title><logo>http://www.youtube.com/img/pic_youtubelogo_123x63.gif</logo><link
+        rel='related' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/users/tubeit20101?client=youtube_it'/><link
+        rel='alternate' type='text/html' href='http://www.youtube.com'/><link rel='http://schemas.google.com/g/2005#feed'
+        type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/users/tubeit20101/playlists?client=youtube_it'/><link
+        rel='http://schemas.google.com/g/2005#post' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/users/tubeit20101/playlists?client=youtube_it'/><link
+        rel='http://schemas.google.com/g/2005#batch' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/users/tubeit20101/playlists/batch?client=youtube_it'/><link
+        rel='self' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/users/tubeit20101/playlists?start-index=1&amp;max-results=25&amp;client=youtube_it'/><link
+        rel='service' type='application/atomsvc+xml' href='http://gdata.youtube.com/feeds/api/users/tubeit20101/playlists?alt=atom-service'/><author><name>tubeit20101</name><uri>http://gdata.youtube.com/feeds/api/users/tubeit20101</uri><yt:userId>WWmLvppy3j64IGmA2dpCyw</yt:userId></author><generator
+        version='2.1' uri='http://gdata.youtube.com'>YouTube data API</generator><openSearch:totalResults>0</openSearch:totalResults><openSearch:startIndex>1</openSearch:startIndex><openSearch:itemsPerPage>25</openSearch:itemsPerPage></feed>
+    http_version: 
+  recorded_at: Thu, 07 Feb 2013 12:11:10 GMT
+- request:
+    method: post
+    uri: http://gdata.youtube.com/feeds/api/users/default/playlists
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8"?><entry xmlns="http://www.w3.org/2005/Atom"
+        xmlns:yt="http://gdata.youtube.com/schemas/2007"><title>youtube_it test!</title><summary>test
+        playlist</summary></entry>
+    headers:
+      Authorization:
+      - Bearer ya29.AHES6ZRjjO5OHP2P3EfAKE0eTFwG9kSRey4LLw3-QzDCtXM
+      X-Gdata-Client:
+      - youtube_it
+      X-Gdata-Key:
+      - key=AI39si7WuZZxAkYebKSyrlJR7hIFktt6OoPycEOeOT_yHkZgr6QsGbZgmhKvbS4bsSAv0utgrfhNfXQBITu1wX_z3VsZE02giQ
+      Gdata-Version:
+      - '2'
+      Content-Type:
+      - application/atom+xml; charset=UTF-8
+      Content-Length:
+      - '201'
+      Accept:
+      - ! '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Gdata-User-Country:
+      - PL
+      Content-Type:
+      - application/atom+xml; charset=UTF-8; type=entry
+      Expires:
+      - Thu, 07 Feb 2013 12:11:11 GMT
+      Date:
+      - Thu, 07 Feb 2013 12:11:11 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Accept, X-GData-Authorization, GData-Version
+      Gdata-Version:
+      - '2.1'
+      Etag:
+      - W/"A0cDQX47eCp7I2A9WhBTEk4."
+      Location:
+      - http://gdata.youtube.com/feeds/api/users/tubeit20101/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq?client=youtube_it
+      Content-Location:
+      - http://gdata.youtube.com/feeds/api/users/tubeit20101/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq?client=youtube_it
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+    body:
+      encoding: US-ASCII
+      string: <?xml version='1.0' encoding='UTF-8'?><entry xmlns='http://www.w3.org/2005/Atom'
+        xmlns:app='http://www.w3.org/2007/app' xmlns:media='http://search.yahoo.com/mrss/'
+        xmlns:gd='http://schemas.google.com/g/2005' xmlns:yt='http://gdata.youtube.com/schemas/2007'
+        gd:etag='W/&quot;A0cDQX47eCp7I2A9WhBTEk4.&quot;'><id>tag:youtube.com,2008:user:tubeit20101:playlist:PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq</id><published>2013-02-07T12:11:10.000Z</published><updated>2013-02-07T12:11:10.000Z</updated><app:edited>2013-02-07T12:11:10.000Z</app:edited><category
+        scheme='http://schemas.google.com/g/2005#kind' term='http://gdata.youtube.com/schemas/2007#playlistLink'/><title>youtube_it
+        test!</title><summary>test playlist</summary><content type='application/atom+xml;type=feed'
+        src='http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq'/><link
+        rel='related' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/users/tubeit20101?client=youtube_it'/><link
+        rel='alternate' type='text/html' href='http://www.youtube.com/playlist?list=PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq'/><link
+        rel='self' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/users/tubeit20101/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq?client=youtube_it'/><link
+        rel='edit' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/users/tubeit20101/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq?client=youtube_it'/><author><name>tubeit20101</name><uri>http://gdata.youtube.com/feeds/api/users/tubeit20101</uri><yt:userId>WWmLvppy3j64IGmA2dpCyw</yt:userId></author><yt:countHint>0</yt:countHint><media:group><yt:duration
+        seconds='0'/></media:group><yt:playlistId>PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq</yt:playlistId></entry>
+    http_version: 
+  recorded_at: Thu, 07 Feb 2013 12:11:11 GMT
+- request:
+    method: post
+    uri: http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8"?><entry xmlns="http://www.w3.org/2005/Atom"
+        xmlns:yt="http://gdata.youtube.com/schemas/2007"><id>fFAnoEYFUQw</id></entry>
+    headers:
+      Authorization:
+      - Bearer ya29.AHES6ZRjjO5OHP2P3EfAKE0eTFwG9kSRey4LLw3-QzDCtXM
+      X-Gdata-Client:
+      - youtube_it
+      X-Gdata-Key:
+      - key=AI39si7WuZZxAkYebKSyrlJR7hIFktt6OoPycEOeOT_yHkZgr6QsGbZgmhKvbS4bsSAv0utgrfhNfXQBITu1wX_z3VsZE02giQ
+      Gdata-Version:
+      - '2'
+      Content-Type:
+      - application/atom+xml; charset=UTF-8
+      Content-Length:
+      - '158'
+      Accept:
+      - ! '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Gdata-User-Country:
+      - PL
+      Content-Type:
+      - application/atom+xml; charset=UTF-8; type=entry
+      Expires:
+      - Thu, 07 Feb 2013 12:11:12 GMT
+      Date:
+      - Thu, 07 Feb 2013 12:11:12 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Accept, X-GData-Authorization, GData-Version
+      Gdata-Version:
+      - '2.1'
+      Etag:
+      - W/"YDwqeyM."
+      Location:
+      - http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq/PLQFFVwEah2EM7dO-1K2EDoQTh1SnF_T39Cl-eQEkUtyE?client=youtube_it
+      Content-Location:
+      - http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq/PLQFFVwEah2EM7dO-1K2EDoQTh1SnF_T39Cl-eQEkUtyE?client=youtube_it
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+    body:
+      encoding: US-ASCII
+      string: <?xml version='1.0' encoding='UTF-8'?><entry xmlns='http://www.w3.org/2005/Atom'
+        xmlns:app='http://www.w3.org/2007/app' xmlns:media='http://search.yahoo.com/mrss/'
+        xmlns:gd='http://schemas.google.com/g/2005' xmlns:yt='http://gdata.youtube.com/schemas/2007'
+        gd:etag='W/&quot;YDwqeyM.&quot;'><id>tag:youtube.com,2008:playlist:PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq:PLQFFVwEah2EM7dO-1K2EDoQTh1SnF_T39Cl-eQEkUtyE</id><published>2013-02-07T12:11:11.000Z</published><updated>1970-01-01T00:00:00.000Z</updated><app:edited>1970-01-01T00:00:00.000Z</app:edited><category
+        scheme='http://schemas.google.com/g/2005#kind' term='http://gdata.youtube.com/schemas/2007#video'/><category
+        scheme='http://gdata.youtube.com/schemas/2007/categories.cat' term='Entertainment'
+        label='Entertainment'/><title>Boris The Bad Dog</title><content type='application/x-shockwave-flash'
+        src='http://www.youtube.com/v/fFAnoEYFUQw?version=3&amp;f=playlists&amp;c=youtube_it&amp;d=Af_sMkfuv5bHKDHIEIvKuwwO88HsQjpE1a8d1GxQnGDm&amp;app=youtube_gdata'/><link
+        rel='alternate' type='text/html' href='http://www.youtube.com/watch?v=fFAnoEYFUQw&amp;feature=youtube_gdata'/><link
+        rel='http://gdata.youtube.com/schemas/2007#video.responses' type='application/atom+xml'
+        href='http://gdata.youtube.com/feeds/api/videos/fFAnoEYFUQw/responses?client=youtube_it'/><link
+        rel='http://gdata.youtube.com/schemas/2007#video.ratings' type='application/atom+xml'
+        href='http://gdata.youtube.com/feeds/api/videos/fFAnoEYFUQw/ratings?client=youtube_it'/><link
+        rel='http://gdata.youtube.com/schemas/2007#video.complaints' type='application/atom+xml'
+        href='http://gdata.youtube.com/feeds/api/videos/fFAnoEYFUQw/complaints?client=youtube_it'/><link
+        rel='http://gdata.youtube.com/schemas/2007#video.related' type='application/atom+xml'
+        href='http://gdata.youtube.com/feeds/api/videos/fFAnoEYFUQw/related?client=youtube_it'/><link
+        rel='http://gdata.youtube.com/schemas/2007#mobile' type='text/html' href='http://m.youtube.com/details?v=fFAnoEYFUQw'/><link
+        rel='http://gdata.youtube.com/schemas/2007#uploader' type='application/atom+xml'
+        href='http://gdata.youtube.com/feeds/api/users/_EPuqJjzjgM7o0rZns01mg?client=youtube_it'/><link
+        rel='related' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/videos/fFAnoEYFUQw?client=youtube_it'/><link
+        rel='self' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq/PLQFFVwEah2EM7dO-1K2EDoQTh1SnF_T39Cl-eQEkUtyE?client=youtube_it'/><link
+        rel='edit' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq/PLQFFVwEah2EM7dO-1K2EDoQTh1SnF_T39Cl-eQEkUtyE?client=youtube_it'/><author><name>tubeit20101</name><uri>http://gdata.youtube.com/feeds/api/users/tubeit20101</uri><yt:userId>WWmLvppy3j64IGmA2dpCyw</yt:userId></author><yt:accessControl
+        action='comment' permission='allowed'/><yt:accessControl action='commentVote'
+        permission='allowed'/><yt:accessControl action='videoRespond' permission='moderated'/><yt:accessControl
+        action='rate' permission='allowed'/><yt:accessControl action='embed' permission='allowed'/><yt:accessControl
+        action='list' permission='allowed'/><yt:accessControl action='autoPlay' permission='allowed'/><yt:accessControl
+        action='syndicate' permission='allowed'/><gd:comments><gd:feedLink rel='http://gdata.youtube.com/schemas/2007#comments'
+        href='http://gdata.youtube.com/feeds/api/videos/fFAnoEYFUQw/comments?client=youtube_it'
+        countHint='0'/></gd:comments><yt:hd/><media:group><media:category label='Entertainment'
+        scheme='http://gdata.youtube.com/schemas/2007/categories.cat'>Entertainment</media:category><media:content
+        url='http://www.youtube.com/v/fFAnoEYFUQw?version=3&amp;f=playlists&amp;c=youtube_it&amp;d=Af_sMkfuv5bHKDHIEIvKuwwO88HsQjpE1a8d1GxQnGDm&amp;app=youtube_gdata'
+        type='application/x-shockwave-flash' medium='video' isDefault='true' expression='full'
+        duration='63' yt:format='5'/><media:content url='rtsp://v8.cache2.c.youtube.com/ClQLENy73wIaSwkMUQVGoCdQfBMYDSANFEIKeW91dHViZV9pdEgGUglwbGF5bGlzdHNyIQH_7DJH7r-WxygxyBCLyrsMDvPB7EI6RNWvHdRsUJxg5gw=/0/0/0/video.3gp'
+        type='video/3gpp' medium='video' expression='full' duration='63' yt:format='1'/><media:content
+        url='rtsp://v8.cache2.c.youtube.com/ClQLENy73wIaSwkMUQVGoCdQfBMYESARFEIKeW91dHViZV9pdEgGUglwbGF5bGlzdHNyIQH_7DJH7r-WxygxyBCLyrsMDvPB7EI6RNWvHdRsUJxg5gw=/0/0/0/video.3gp'
+        type='video/3gpp' medium='video' expression='full' duration='63' yt:format='6'/><media:credit
+        role='uploader' scheme='urn:youtube' yt:display='Mauro Torres'>chebyte2006</media:credit><media:description
+        type='plain'>Historia de un perro malo</media:description><media:keywords/><media:license
+        type='text/html' href='http://www.youtube.com/t/terms'>youtube</media:license><media:player
+        url='http://www.youtube.com/watch?v=fFAnoEYFUQw&amp;feature=youtube_gdata_player'/><media:thumbnail
+        url='http://i.ytimg.com/vi/fFAnoEYFUQw/default.jpg' height='90' width='120'
+        time='00:00:31.500' yt:name='default'/><media:thumbnail url='http://i.ytimg.com/vi/fFAnoEYFUQw/mqdefault.jpg'
+        height='180' width='320' yt:name='mqdefault'/><media:thumbnail url='http://i.ytimg.com/vi/fFAnoEYFUQw/hqdefault.jpg'
+        height='360' width='480' yt:name='hqdefault'/><media:thumbnail url='http://i.ytimg.com/vi/fFAnoEYFUQw/sddefault.jpg'
+        height='480' width='640' yt:name='sddefault'/><media:thumbnail url='http://i.ytimg.com/vi/fFAnoEYFUQw/1.jpg'
+        height='90' width='120' time='00:00:15.750' yt:name='start'/><media:thumbnail
+        url='http://i.ytimg.com/vi/fFAnoEYFUQw/2.jpg' height='90' width='120' time='00:00:31.500'
+        yt:name='middle'/><media:thumbnail url='http://i.ytimg.com/vi/fFAnoEYFUQw/3.jpg'
+        height='90' width='120' time='00:00:47.250' yt:name='end'/><media:title type='plain'>Boris
+        The Bad Dog</media:title><yt:aspectRatio>widescreen</yt:aspectRatio><yt:duration
+        seconds='63'/><yt:uploaded>2012-03-21T20:27:55.000Z</yt:uploaded><yt:uploaderId>UC_EPuqJjzjgM7o0rZns01mg</yt:uploaderId><yt:videoid>fFAnoEYFUQw</yt:videoid></media:group><yt:statistics
+        favoriteCount='0' viewCount='91'/><yt:position>1</yt:position></entry>
+    http_version: 
+  recorded_at: Thu, 07 Feb 2013 12:11:12 GMT
+- request:
+    method: post
+    uri: http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8"?><entry xmlns="http://www.w3.org/2005/Atom"
+        xmlns:yt="http://gdata.youtube.com/schemas/2007"><id>QsbmrCtiEUU</id></entry>
+    headers:
+      Authorization:
+      - Bearer ya29.AHES6ZRjjO5OHP2P3EfAKE0eTFwG9kSRey4LLw3-QzDCtXM
+      X-Gdata-Client:
+      - youtube_it
+      X-Gdata-Key:
+      - key=AI39si7WuZZxAkYebKSyrlJR7hIFktt6OoPycEOeOT_yHkZgr6QsGbZgmhKvbS4bsSAv0utgrfhNfXQBITu1wX_z3VsZE02giQ
+      Gdata-Version:
+      - '2'
+      Content-Type:
+      - application/atom+xml; charset=UTF-8
+      Content-Length:
+      - '158'
+      Accept:
+      - ! '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Gdata-User-Country:
+      - PL
+      Content-Type:
+      - application/atom+xml; charset=UTF-8; type=entry
+      Expires:
+      - Thu, 07 Feb 2013 12:11:12 GMT
+      Date:
+      - Thu, 07 Feb 2013 12:11:12 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Accept, X-GData-Authorization, GData-Version
+      Gdata-Version:
+      - '2.1'
+      Etag:
+      - W/"YDwqeyM."
+      Location:
+      - http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq/PLQFFVwEah2EM7dO-1K2EDoWP7ywoUM_kYXlbHDrNP6y8?client=youtube_it
+      Content-Location:
+      - http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq/PLQFFVwEah2EM7dO-1K2EDoWP7ywoUM_kYXlbHDrNP6y8?client=youtube_it
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+    body:
+      encoding: US-ASCII
+      string: <?xml version='1.0' encoding='UTF-8'?><entry xmlns='http://www.w3.org/2005/Atom'
+        xmlns:app='http://www.w3.org/2007/app' xmlns:media='http://search.yahoo.com/mrss/'
+        xmlns:gd='http://schemas.google.com/g/2005' xmlns:yt='http://gdata.youtube.com/schemas/2007'
+        gd:etag='W/&quot;YDwqeyM.&quot;'><id>tag:youtube.com,2008:playlist:PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq:PLQFFVwEah2EM7dO-1K2EDoWP7ywoUM_kYXlbHDrNP6y8</id><published>2013-02-07T12:11:12.000Z</published><updated>1970-01-01T00:00:00.000Z</updated><app:edited>1970-01-01T00:00:00.000Z</app:edited><category
+        scheme='http://schemas.google.com/g/2005#kind' term='http://gdata.youtube.com/schemas/2007#video'/><category
+        scheme='http://gdata.youtube.com/schemas/2007/categories.cat' term='People'
+        label='People &amp; Blogs'/><title>fundacion tuquito</title><content type='application/x-shockwave-flash'
+        src='http://www.youtube.com/v/QsbmrCtiEUU?version=3&amp;f=playlists&amp;c=youtube_it&amp;d=Af_sMkfuv5bHKDHIEIvKuwwO88HsQjpE1a8d1GxQnGDm&amp;app=youtube_gdata'/><link
+        rel='alternate' type='text/html' href='http://www.youtube.com/watch?v=QsbmrCtiEUU&amp;feature=youtube_gdata'/><link
+        rel='http://gdata.youtube.com/schemas/2007#video.responses' type='application/atom+xml'
+        href='http://gdata.youtube.com/feeds/api/videos/QsbmrCtiEUU/responses?client=youtube_it'/><link
+        rel='http://gdata.youtube.com/schemas/2007#video.ratings' type='application/atom+xml'
+        href='http://gdata.youtube.com/feeds/api/videos/QsbmrCtiEUU/ratings?client=youtube_it'/><link
+        rel='http://gdata.youtube.com/schemas/2007#video.complaints' type='application/atom+xml'
+        href='http://gdata.youtube.com/feeds/api/videos/QsbmrCtiEUU/complaints?client=youtube_it'/><link
+        rel='http://gdata.youtube.com/schemas/2007#video.related' type='application/atom+xml'
+        href='http://gdata.youtube.com/feeds/api/videos/QsbmrCtiEUU/related?client=youtube_it'/><link
+        rel='http://gdata.youtube.com/schemas/2007#mobile' type='text/html' href='http://m.youtube.com/details?v=QsbmrCtiEUU'/><link
+        rel='http://gdata.youtube.com/schemas/2007#uploader' type='application/atom+xml'
+        href='http://gdata.youtube.com/feeds/api/users/_EPuqJjzjgM7o0rZns01mg?client=youtube_it'/><link
+        rel='related' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/videos/QsbmrCtiEUU?client=youtube_it'/><link
+        rel='self' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq/PLQFFVwEah2EM7dO-1K2EDoWP7ywoUM_kYXlbHDrNP6y8?client=youtube_it'/><link
+        rel='edit' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq/PLQFFVwEah2EM7dO-1K2EDoWP7ywoUM_kYXlbHDrNP6y8?client=youtube_it'/><author><name>tubeit20101</name><uri>http://gdata.youtube.com/feeds/api/users/tubeit20101</uri><yt:userId>WWmLvppy3j64IGmA2dpCyw</yt:userId></author><yt:accessControl
+        action='comment' permission='allowed'/><yt:accessControl action='commentVote'
+        permission='allowed'/><yt:accessControl action='videoRespond' permission='moderated'/><yt:accessControl
+        action='rate' permission='allowed'/><yt:accessControl action='embed' permission='allowed'/><yt:accessControl
+        action='list' permission='allowed'/><yt:accessControl action='autoPlay' permission='allowed'/><yt:accessControl
+        action='syndicate' permission='allowed'/><gd:comments><gd:feedLink rel='http://gdata.youtube.com/schemas/2007#comments'
+        href='http://gdata.youtube.com/feeds/api/videos/QsbmrCtiEUU/comments?client=youtube_it'
+        countHint='0'/></gd:comments><yt:hd/><media:group><media:category label='People
+        &amp; Blogs' scheme='http://gdata.youtube.com/schemas/2007/categories.cat'>People</media:category><media:content
+        url='http://www.youtube.com/v/QsbmrCtiEUU?version=3&amp;f=playlists&amp;c=youtube_it&amp;d=Af_sMkfuv5bHKDHIEIvKuwwO88HsQjpE1a8d1GxQnGDm&amp;app=youtube_gdata'
+        type='application/x-shockwave-flash' medium='video' isDefault='true' expression='full'
+        duration='127' yt:format='5'/><media:content url='rtsp://r2---sn-4g57kuek.c.youtube.com/ClQLENy73wIaSwlFEWIrrObGQhMYDSANFEIKeW91dHViZV9pdEgGUglwbGF5bGlzdHNyIQH_7DJH7r-WxygxyBCLyrsMDvPB7EI6RNWvHdRsUJxg5gw=/0/0/0/video.3gp'
+        type='video/3gpp' medium='video' expression='full' duration='127' yt:format='1'/><media:content
+        url='rtsp://r2---sn-4g57kuek.c.youtube.com/ClQLENy73wIaSwlFEWIrrObGQhMYESARFEIKeW91dHViZV9pdEgGUglwbGF5bGlzdHNyIQH_7DJH7r-WxygxyBCLyrsMDvPB7EI6RNWvHdRsUJxg5gw=/0/0/0/video.3gp'
+        type='video/3gpp' medium='video' expression='full' duration='127' yt:format='6'/><media:credit
+        role='uploader' scheme='urn:youtube' yt:display='Mauro Torres'>chebyte2006</media:credit><media:description
+        type='plain'>video de la problematica actual que afronta el mundo</media:description><media:keywords/><media:license
+        type='text/html' href='http://www.youtube.com/t/terms'>youtube</media:license><media:player
+        url='http://www.youtube.com/watch?v=QsbmrCtiEUU&amp;feature=youtube_gdata_player'/><media:thumbnail
+        url='http://i.ytimg.com/vi/QsbmrCtiEUU/default.jpg' height='90' width='120'
+        time='00:01:03.500' yt:name='default'/><media:thumbnail url='http://i.ytimg.com/vi/QsbmrCtiEUU/mqdefault.jpg'
+        height='180' width='320' yt:name='mqdefault'/><media:thumbnail url='http://i.ytimg.com/vi/QsbmrCtiEUU/hqdefault.jpg'
+        height='360' width='480' yt:name='hqdefault'/><media:thumbnail url='http://i.ytimg.com/vi/QsbmrCtiEUU/sddefault.jpg'
+        height='480' width='640' yt:name='sddefault'/><media:thumbnail url='http://i.ytimg.com/vi/QsbmrCtiEUU/1.jpg'
+        height='90' width='120' time='00:00:31.750' yt:name='start'/><media:thumbnail
+        url='http://i.ytimg.com/vi/QsbmrCtiEUU/2.jpg' height='90' width='120' time='00:01:03.500'
+        yt:name='middle'/><media:thumbnail url='http://i.ytimg.com/vi/QsbmrCtiEUU/3.jpg'
+        height='90' width='120' time='00:01:35.250' yt:name='end'/><media:title type='plain'>fundacion
+        tuquito</media:title><yt:aspectRatio>widescreen</yt:aspectRatio><yt:duration
+        seconds='127'/><yt:uploaded>2011-10-14T13:17:53.000Z</yt:uploaded><yt:uploaderId>UC_EPuqJjzjgM7o0rZns01mg</yt:uploaderId><yt:videoid>QsbmrCtiEUU</yt:videoid></media:group><gd:rating
+        average='5.0' max='5' min='1' numRaters='3' rel='http://schemas.google.com/g/2005#overall'/><yt:statistics
+        favoriteCount='0' viewCount='373'/><yt:rating numDislikes='0' numLikes='3'/><yt:position>2</yt:position></entry>
+    http_version: 
+  recorded_at: Thu, 07 Feb 2013 12:11:13 GMT
+- request:
+    method: get
+    uri: http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq?max-results=1&orderby=title&start-index=1&v=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer ya29.AHES6ZRjjO5OHP2P3EfAKE0eTFwG9kSRey4LLw3-QzDCtXM
+      X-Gdata-Client:
+      - youtube_it
+      X-Gdata-Key:
+      - key=AI39si7WuZZxAkYebKSyrlJR7hIFktt6OoPycEOeOT_yHkZgr6QsGbZgmhKvbS4bsSAv0utgrfhNfXQBITu1wX_z3VsZE02giQ
+      Gdata-Version:
+      - '2'
+      Content-Type:
+      - application/atom+xml; charset=UTF-8
+      Content-Length:
+      - '0'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - ! '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Gdata-User-Country:
+      - PL
+      Content-Type:
+      - application/atom+xml; charset=UTF-8; type=feed
+      Expires:
+      - Thu, 07 Feb 2013 12:11:17 GMT
+      Date:
+      - Thu, 07 Feb 2013 12:11:17 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Accept, X-GData-Authorization, GData-Version
+      Gdata-Version:
+      - '2.1'
+      Etag:
+      - W/"A0cDQX47eCp7I2A9WhBTEk4."
+      Last-Modified:
+      - Thu, 07 Feb 2013 12:11:10 GMT
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+    body:
+      encoding: US-ASCII
+      string: <?xml version='1.0' encoding='UTF-8'?><feed xmlns='http://www.w3.org/2005/Atom'
+        xmlns:app='http://www.w3.org/2007/app' xmlns:media='http://search.yahoo.com/mrss/'
+        xmlns:openSearch='http://a9.com/-/spec/opensearch/1.1/' xmlns:gd='http://schemas.google.com/g/2005'
+        xmlns:yt='http://gdata.youtube.com/schemas/2007' gd:etag='W/&quot;A0cDQX47eCp7I2A9WhBTEk4.&quot;'><id>tag:youtube.com,2008:playlist:PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq</id><updated>2013-02-07T12:11:10.000Z</updated><category
+        scheme='http://schemas.google.com/g/2005#kind' term='http://gdata.youtube.com/schemas/2007#playlist'/><title>youtube_it
+        test!</title><subtitle>test playlist</subtitle><logo>http://www.youtube.com/img/pic_youtubelogo_123x63.gif</logo><link
+        rel='alternate' type='text/html' href='http://www.youtube.com/playlist?list=PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq'/><link
+        rel='http://schemas.google.com/g/2005#feed' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq?client=youtube_it'/><link
+        rel='http://schemas.google.com/g/2005#post' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq?client=youtube_it'/><link
+        rel='http://schemas.google.com/g/2005#batch' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq/batch?client=youtube_it'/><link
+        rel='self' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq?start-index=1&amp;max-results=1&amp;orderby=title&amp;client=youtube_it'/><link
+        rel='service' type='application/atomsvc+xml' href='http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq?alt=atom-service'/><link
+        rel='next' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq?start-index=2&amp;max-results=1&amp;orderby=title&amp;client=youtube_it'/><author><name>tubeit20101</name><uri>http://gdata.youtube.com/feeds/api/users/tubeit20101</uri><yt:userId>WWmLvppy3j64IGmA2dpCyw</yt:userId></author><generator
+        version='2.1' uri='http://gdata.youtube.com'>YouTube data API</generator><openSearch:totalResults>2</openSearch:totalResults><openSearch:startIndex>1</openSearch:startIndex><openSearch:itemsPerPage>1</openSearch:itemsPerPage><media:group><media:content
+        url='http://www.youtube.com/p/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq' type='application/x-shockwave-flash'
+        yt:format='5'/><media:description type='plain'>test playlist</media:description><media:thumbnail
+        url='http://i.ytimg.com/vi/fFAnoEYFUQw/default.jpg' height='90' width='120'
+        yt:name='default'/><media:thumbnail url='http://i.ytimg.com/vi/fFAnoEYFUQw/mqdefault.jpg'
+        height='180' width='320' yt:name='mqdefault'/><media:thumbnail url='http://i.ytimg.com/vi/fFAnoEYFUQw/hqdefault.jpg'
+        height='360' width='480' yt:name='hqdefault'/><media:title type='plain'>youtube_it
+        test!</media:title></media:group><yt:playlistId>PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq</yt:playlistId><entry
+        gd:etag='W/&quot;YDwqeyM.&quot;'><id>tag:youtube.com,2008:playlist:PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq:PLQFFVwEah2EM7dO-1K2EDoQTh1SnF_T39Cl-eQEkUtyE</id><published>2013-02-07T12:11:11.000Z</published><updated>1970-01-01T00:00:00.000Z</updated><app:edited>1970-01-01T00:00:00.000Z</app:edited><category
+        scheme='http://schemas.google.com/g/2005#kind' term='http://gdata.youtube.com/schemas/2007#video'/><category
+        scheme='http://gdata.youtube.com/schemas/2007/categories.cat' term='Entertainment'
+        label='Entertainment'/><title>Boris The Bad Dog</title><content type='application/x-shockwave-flash'
+        src='http://www.youtube.com/v/fFAnoEYFUQw?version=3&amp;f=playlists&amp;c=youtube_it&amp;d=Af_sMkfuv5bHKDHIEIvKuwwO88HsQjpE1a8d1GxQnGDm&amp;app=youtube_gdata'/><link
+        rel='alternate' type='text/html' href='http://www.youtube.com/watch?v=fFAnoEYFUQw&amp;feature=youtube_gdata'/><link
+        rel='http://gdata.youtube.com/schemas/2007#video.responses' type='application/atom+xml'
+        href='http://gdata.youtube.com/feeds/api/videos/fFAnoEYFUQw/responses?client=youtube_it'/><link
+        rel='http://gdata.youtube.com/schemas/2007#video.ratings' type='application/atom+xml'
+        href='http://gdata.youtube.com/feeds/api/videos/fFAnoEYFUQw/ratings?client=youtube_it'/><link
+        rel='http://gdata.youtube.com/schemas/2007#video.complaints' type='application/atom+xml'
+        href='http://gdata.youtube.com/feeds/api/videos/fFAnoEYFUQw/complaints?client=youtube_it'/><link
+        rel='http://gdata.youtube.com/schemas/2007#video.related' type='application/atom+xml'
+        href='http://gdata.youtube.com/feeds/api/videos/fFAnoEYFUQw/related?client=youtube_it'/><link
+        rel='http://gdata.youtube.com/schemas/2007#mobile' type='text/html' href='http://m.youtube.com/details?v=fFAnoEYFUQw'/><link
+        rel='http://gdata.youtube.com/schemas/2007#uploader' type='application/atom+xml'
+        href='http://gdata.youtube.com/feeds/api/users/_EPuqJjzjgM7o0rZns01mg?client=youtube_it'/><link
+        rel='related' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/videos/fFAnoEYFUQw?client=youtube_it'/><link
+        rel='self' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq/PLQFFVwEah2EM7dO-1K2EDoQTh1SnF_T39Cl-eQEkUtyE?client=youtube_it'/><link
+        rel='edit' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq/PLQFFVwEah2EM7dO-1K2EDoQTh1SnF_T39Cl-eQEkUtyE?client=youtube_it'/><author><name>tubeit20101</name><uri>http://gdata.youtube.com/feeds/api/users/tubeit20101</uri><yt:userId>WWmLvppy3j64IGmA2dpCyw</yt:userId></author><yt:accessControl
+        action='comment' permission='allowed'/><yt:accessControl action='commentVote'
+        permission='allowed'/><yt:accessControl action='videoRespond' permission='moderated'/><yt:accessControl
+        action='rate' permission='allowed'/><yt:accessControl action='embed' permission='allowed'/><yt:accessControl
+        action='list' permission='allowed'/><yt:accessControl action='autoPlay' permission='allowed'/><yt:accessControl
+        action='syndicate' permission='allowed'/><gd:comments><gd:feedLink rel='http://gdata.youtube.com/schemas/2007#comments'
+        href='http://gdata.youtube.com/feeds/api/videos/fFAnoEYFUQw/comments?client=youtube_it'
+        countHint='0'/></gd:comments><yt:hd/><media:group><media:category label='Entertainment'
+        scheme='http://gdata.youtube.com/schemas/2007/categories.cat'>Entertainment</media:category><media:content
+        url='http://www.youtube.com/v/fFAnoEYFUQw?version=3&amp;f=playlists&amp;c=youtube_it&amp;d=Af_sMkfuv5bHKDHIEIvKuwwO88HsQjpE1a8d1GxQnGDm&amp;app=youtube_gdata'
+        type='application/x-shockwave-flash' medium='video' isDefault='true' expression='full'
+        duration='63' yt:format='5'/><media:content url='rtsp://v8.cache2.c.youtube.com/ClQLENy73wIaSwkMUQVGoCdQfBMYDSANFEIKeW91dHViZV9pdEgGUglwbGF5bGlzdHNyIQH_7DJH7r-WxygxyBCLyrsMDvPB7EI6RNWvHdRsUJxg5gw=/0/0/0/video.3gp'
+        type='video/3gpp' medium='video' expression='full' duration='63' yt:format='1'/><media:content
+        url='rtsp://v8.cache2.c.youtube.com/ClQLENy73wIaSwkMUQVGoCdQfBMYESARFEIKeW91dHViZV9pdEgGUglwbGF5bGlzdHNyIQH_7DJH7r-WxygxyBCLyrsMDvPB7EI6RNWvHdRsUJxg5gw=/0/0/0/video.3gp'
+        type='video/3gpp' medium='video' expression='full' duration='63' yt:format='6'/><media:credit
+        role='uploader' scheme='urn:youtube' yt:display='Mauro Torres'>chebyte2006</media:credit><media:description
+        type='plain'>Historia de un perro malo</media:description><media:keywords/><media:license
+        type='text/html' href='http://www.youtube.com/t/terms'>youtube</media:license><media:player
+        url='http://www.youtube.com/watch?v=fFAnoEYFUQw&amp;feature=youtube_gdata_player'/><media:thumbnail
+        url='http://i.ytimg.com/vi/fFAnoEYFUQw/default.jpg' height='90' width='120'
+        time='00:00:31.500' yt:name='default'/><media:thumbnail url='http://i.ytimg.com/vi/fFAnoEYFUQw/mqdefault.jpg'
+        height='180' width='320' yt:name='mqdefault'/><media:thumbnail url='http://i.ytimg.com/vi/fFAnoEYFUQw/hqdefault.jpg'
+        height='360' width='480' yt:name='hqdefault'/><media:thumbnail url='http://i.ytimg.com/vi/fFAnoEYFUQw/sddefault.jpg'
+        height='480' width='640' yt:name='sddefault'/><media:thumbnail url='http://i.ytimg.com/vi/fFAnoEYFUQw/1.jpg'
+        height='90' width='120' time='00:00:15.750' yt:name='start'/><media:thumbnail
+        url='http://i.ytimg.com/vi/fFAnoEYFUQw/2.jpg' height='90' width='120' time='00:00:31.500'
+        yt:name='middle'/><media:thumbnail url='http://i.ytimg.com/vi/fFAnoEYFUQw/3.jpg'
+        height='90' width='120' time='00:00:47.250' yt:name='end'/><media:title type='plain'>Boris
+        The Bad Dog</media:title><yt:aspectRatio>widescreen</yt:aspectRatio><yt:duration
+        seconds='63'/><yt:uploaded>2012-03-21T20:27:55.000Z</yt:uploaded><yt:uploaderId>UC_EPuqJjzjgM7o0rZns01mg</yt:uploaderId><yt:videoid>fFAnoEYFUQw</yt:videoid></media:group><yt:statistics
+        favoriteCount='0' viewCount='91'/><yt:position>1</yt:position></entry></feed>
+    http_version: 
+  recorded_at: Thu, 07 Feb 2013 12:11:17 GMT
+- request:
+    method: get
+    uri: http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq?max-results=1&orderby=title&start-index=2&v=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer ya29.AHES6ZRjjO5OHP2P3EfAKE0eTFwG9kSRey4LLw3-QzDCtXM
+      X-Gdata-Client:
+      - youtube_it
+      X-Gdata-Key:
+      - key=AI39si7WuZZxAkYebKSyrlJR7hIFktt6OoPycEOeOT_yHkZgr6QsGbZgmhKvbS4bsSAv0utgrfhNfXQBITu1wX_z3VsZE02giQ
+      Gdata-Version:
+      - '2'
+      Content-Type:
+      - application/atom+xml; charset=UTF-8
+      Content-Length:
+      - '0'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - ! '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Gdata-User-Country:
+      - PL
+      Content-Type:
+      - application/atom+xml; charset=UTF-8; type=feed
+      Expires:
+      - Thu, 07 Feb 2013 12:11:17 GMT
+      Date:
+      - Thu, 07 Feb 2013 12:11:17 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Accept, X-GData-Authorization, GData-Version
+      Gdata-Version:
+      - '2.1'
+      Etag:
+      - W/"A0cDQX47eCp7I2A9WhBTEk4."
+      Last-Modified:
+      - Thu, 07 Feb 2013 12:11:10 GMT
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+    body:
+      encoding: US-ASCII
+      string: <?xml version='1.0' encoding='UTF-8'?><feed xmlns='http://www.w3.org/2005/Atom'
+        xmlns:app='http://www.w3.org/2007/app' xmlns:media='http://search.yahoo.com/mrss/'
+        xmlns:openSearch='http://a9.com/-/spec/opensearch/1.1/' xmlns:gd='http://schemas.google.com/g/2005'
+        xmlns:yt='http://gdata.youtube.com/schemas/2007' gd:etag='W/&quot;A0cDQX47eCp7I2A9WhBTEk4.&quot;'><id>tag:youtube.com,2008:playlist:PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq</id><updated>2013-02-07T12:11:10.000Z</updated><category
+        scheme='http://schemas.google.com/g/2005#kind' term='http://gdata.youtube.com/schemas/2007#playlist'/><title>youtube_it
+        test!</title><subtitle>test playlist</subtitle><logo>http://www.youtube.com/img/pic_youtubelogo_123x63.gif</logo><link
+        rel='alternate' type='text/html' href='http://www.youtube.com/playlist?list=PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq'/><link
+        rel='http://schemas.google.com/g/2005#feed' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq?client=youtube_it'/><link
+        rel='http://schemas.google.com/g/2005#post' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq?client=youtube_it'/><link
+        rel='http://schemas.google.com/g/2005#batch' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq/batch?client=youtube_it'/><link
+        rel='self' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq?start-index=2&amp;max-results=1&amp;orderby=title&amp;client=youtube_it'/><link
+        rel='service' type='application/atomsvc+xml' href='http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq?alt=atom-service'/><link
+        rel='previous' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq?start-index=1&amp;max-results=1&amp;orderby=title&amp;client=youtube_it'/><author><name>tubeit20101</name><uri>http://gdata.youtube.com/feeds/api/users/tubeit20101</uri><yt:userId>WWmLvppy3j64IGmA2dpCyw</yt:userId></author><generator
+        version='2.1' uri='http://gdata.youtube.com'>YouTube data API</generator><openSearch:totalResults>2</openSearch:totalResults><openSearch:startIndex>2</openSearch:startIndex><openSearch:itemsPerPage>1</openSearch:itemsPerPage><media:group><media:content
+        url='http://www.youtube.com/p/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq' type='application/x-shockwave-flash'
+        yt:format='5'/><media:description type='plain'>test playlist</media:description><media:thumbnail
+        url='http://i.ytimg.com/vi/fFAnoEYFUQw/default.jpg' height='90' width='120'
+        yt:name='default'/><media:thumbnail url='http://i.ytimg.com/vi/fFAnoEYFUQw/mqdefault.jpg'
+        height='180' width='320' yt:name='mqdefault'/><media:thumbnail url='http://i.ytimg.com/vi/fFAnoEYFUQw/hqdefault.jpg'
+        height='360' width='480' yt:name='hqdefault'/><media:title type='plain'>youtube_it
+        test!</media:title></media:group><yt:playlistId>PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq</yt:playlistId><entry
+        gd:etag='W/&quot;YDwqeyM.&quot;'><id>tag:youtube.com,2008:playlist:PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq:PLQFFVwEah2EM7dO-1K2EDoWP7ywoUM_kYXlbHDrNP6y8</id><published>2013-02-07T12:11:12.000Z</published><updated>1970-01-01T00:00:00.000Z</updated><app:edited>1970-01-01T00:00:00.000Z</app:edited><category
+        scheme='http://schemas.google.com/g/2005#kind' term='http://gdata.youtube.com/schemas/2007#video'/><category
+        scheme='http://gdata.youtube.com/schemas/2007/categories.cat' term='People'
+        label='People &amp; Blogs'/><title>fundacion tuquito</title><content type='application/x-shockwave-flash'
+        src='http://www.youtube.com/v/QsbmrCtiEUU?version=3&amp;f=playlists&amp;c=youtube_it&amp;d=Af_sMkfuv5bHKDHIEIvKuwwO88HsQjpE1a8d1GxQnGDm&amp;app=youtube_gdata'/><link
+        rel='alternate' type='text/html' href='http://www.youtube.com/watch?v=QsbmrCtiEUU&amp;feature=youtube_gdata'/><link
+        rel='http://gdata.youtube.com/schemas/2007#video.responses' type='application/atom+xml'
+        href='http://gdata.youtube.com/feeds/api/videos/QsbmrCtiEUU/responses?client=youtube_it'/><link
+        rel='http://gdata.youtube.com/schemas/2007#video.ratings' type='application/atom+xml'
+        href='http://gdata.youtube.com/feeds/api/videos/QsbmrCtiEUU/ratings?client=youtube_it'/><link
+        rel='http://gdata.youtube.com/schemas/2007#video.complaints' type='application/atom+xml'
+        href='http://gdata.youtube.com/feeds/api/videos/QsbmrCtiEUU/complaints?client=youtube_it'/><link
+        rel='http://gdata.youtube.com/schemas/2007#video.related' type='application/atom+xml'
+        href='http://gdata.youtube.com/feeds/api/videos/QsbmrCtiEUU/related?client=youtube_it'/><link
+        rel='http://gdata.youtube.com/schemas/2007#mobile' type='text/html' href='http://m.youtube.com/details?v=QsbmrCtiEUU'/><link
+        rel='http://gdata.youtube.com/schemas/2007#uploader' type='application/atom+xml'
+        href='http://gdata.youtube.com/feeds/api/users/_EPuqJjzjgM7o0rZns01mg?client=youtube_it'/><link
+        rel='related' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/videos/QsbmrCtiEUU?client=youtube_it'/><link
+        rel='self' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq/PLQFFVwEah2EM7dO-1K2EDoWP7ywoUM_kYXlbHDrNP6y8?client=youtube_it'/><link
+        rel='edit' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq/PLQFFVwEah2EM7dO-1K2EDoWP7ywoUM_kYXlbHDrNP6y8?client=youtube_it'/><author><name>tubeit20101</name><uri>http://gdata.youtube.com/feeds/api/users/tubeit20101</uri><yt:userId>WWmLvppy3j64IGmA2dpCyw</yt:userId></author><yt:accessControl
+        action='comment' permission='allowed'/><yt:accessControl action='commentVote'
+        permission='allowed'/><yt:accessControl action='videoRespond' permission='moderated'/><yt:accessControl
+        action='rate' permission='allowed'/><yt:accessControl action='embed' permission='allowed'/><yt:accessControl
+        action='list' permission='allowed'/><yt:accessControl action='autoPlay' permission='allowed'/><yt:accessControl
+        action='syndicate' permission='allowed'/><gd:comments><gd:feedLink rel='http://gdata.youtube.com/schemas/2007#comments'
+        href='http://gdata.youtube.com/feeds/api/videos/QsbmrCtiEUU/comments?client=youtube_it'
+        countHint='0'/></gd:comments><yt:hd/><media:group><media:category label='People
+        &amp; Blogs' scheme='http://gdata.youtube.com/schemas/2007/categories.cat'>People</media:category><media:content
+        url='http://www.youtube.com/v/QsbmrCtiEUU?version=3&amp;f=playlists&amp;c=youtube_it&amp;d=Af_sMkfuv5bHKDHIEIvKuwwO88HsQjpE1a8d1GxQnGDm&amp;app=youtube_gdata'
+        type='application/x-shockwave-flash' medium='video' isDefault='true' expression='full'
+        duration='127' yt:format='5'/><media:content url='rtsp://r2---sn-4g57kuek.c.youtube.com/ClQLENy73wIaSwlFEWIrrObGQhMYDSANFEIKeW91dHViZV9pdEgGUglwbGF5bGlzdHNyIQH_7DJH7r-WxygxyBCLyrsMDvPB7EI6RNWvHdRsUJxg5gw=/0/0/0/video.3gp'
+        type='video/3gpp' medium='video' expression='full' duration='127' yt:format='1'/><media:content
+        url='rtsp://r2---sn-4g57kuek.c.youtube.com/ClQLENy73wIaSwlFEWIrrObGQhMYESARFEIKeW91dHViZV9pdEgGUglwbGF5bGlzdHNyIQH_7DJH7r-WxygxyBCLyrsMDvPB7EI6RNWvHdRsUJxg5gw=/0/0/0/video.3gp'
+        type='video/3gpp' medium='video' expression='full' duration='127' yt:format='6'/><media:credit
+        role='uploader' scheme='urn:youtube' yt:display='Mauro Torres'>chebyte2006</media:credit><media:description
+        type='plain'>video de la problematica actual que afronta el mundo</media:description><media:keywords/><media:license
+        type='text/html' href='http://www.youtube.com/t/terms'>youtube</media:license><media:player
+        url='http://www.youtube.com/watch?v=QsbmrCtiEUU&amp;feature=youtube_gdata_player'/><media:thumbnail
+        url='http://i.ytimg.com/vi/QsbmrCtiEUU/default.jpg' height='90' width='120'
+        time='00:01:03.500' yt:name='default'/><media:thumbnail url='http://i.ytimg.com/vi/QsbmrCtiEUU/mqdefault.jpg'
+        height='180' width='320' yt:name='mqdefault'/><media:thumbnail url='http://i.ytimg.com/vi/QsbmrCtiEUU/hqdefault.jpg'
+        height='360' width='480' yt:name='hqdefault'/><media:thumbnail url='http://i.ytimg.com/vi/QsbmrCtiEUU/sddefault.jpg'
+        height='480' width='640' yt:name='sddefault'/><media:thumbnail url='http://i.ytimg.com/vi/QsbmrCtiEUU/1.jpg'
+        height='90' width='120' time='00:00:31.750' yt:name='start'/><media:thumbnail
+        url='http://i.ytimg.com/vi/QsbmrCtiEUU/2.jpg' height='90' width='120' time='00:01:03.500'
+        yt:name='middle'/><media:thumbnail url='http://i.ytimg.com/vi/QsbmrCtiEUU/3.jpg'
+        height='90' width='120' time='00:01:35.250' yt:name='end'/><media:title type='plain'>fundacion
+        tuquito</media:title><yt:aspectRatio>widescreen</yt:aspectRatio><yt:duration
+        seconds='127'/><yt:uploaded>2011-10-14T13:17:53.000Z</yt:uploaded><yt:uploaderId>UC_EPuqJjzjgM7o0rZns01mg</yt:uploaderId><yt:videoid>QsbmrCtiEUU</yt:videoid></media:group><gd:rating
+        average='5.0' max='5' min='1' numRaters='3' rel='http://schemas.google.com/g/2005#overall'/><yt:statistics
+        favoriteCount='0' viewCount='373'/><yt:rating numDislikes='0' numLikes='3'/><yt:position>2</yt:position></entry></feed>
+    http_version: 
+  recorded_at: Thu, 07 Feb 2013 12:11:18 GMT
+- request:
+    method: delete
+    uri: http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq/PLQFFVwEah2EM7dO-1K2EDoQTh1SnF_T39Cl-eQEkUtyE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer ya29.AHES6ZRjjO5OHP2P3EfAKE0eTFwG9kSRey4LLw3-QzDCtXM
+      X-Gdata-Client:
+      - youtube_it
+      X-Gdata-Key:
+      - key=AI39si7WuZZxAkYebKSyrlJR7hIFktt6OoPycEOeOT_yHkZgr6QsGbZgmhKvbS4bsSAv0utgrfhNfXQBITu1wX_z3VsZE02giQ
+      Gdata-Version:
+      - '2'
+      Content-Type:
+      - application/atom+xml; charset=UTF-8
+      Content-Length:
+      - '0'
+      Accept:
+      - ! '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Gdata-User-Country:
+      - PL
+      Gdata-Version:
+      - '2.1'
+      Date:
+      - Thu, 07 Feb 2013 12:11:17 GMT
+      Expires:
+      - Thu, 07 Feb 2013 12:11:17 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '0'
+      Server:
+      - GSE
+      Content-Type:
+      - text/html; charset=UTF-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 07 Feb 2013 12:11:18 GMT
+- request:
+    method: delete
+    uri: http://gdata.youtube.com/feeds/api/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq/PLQFFVwEah2EM7dO-1K2EDoWP7ywoUM_kYXlbHDrNP6y8
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer ya29.AHES6ZRjjO5OHP2P3EfAKE0eTFwG9kSRey4LLw3-QzDCtXM
+      X-Gdata-Client:
+      - youtube_it
+      X-Gdata-Key:
+      - key=AI39si7WuZZxAkYebKSyrlJR7hIFktt6OoPycEOeOT_yHkZgr6QsGbZgmhKvbS4bsSAv0utgrfhNfXQBITu1wX_z3VsZE02giQ
+      Gdata-Version:
+      - '2'
+      Content-Type:
+      - application/atom+xml; charset=UTF-8
+      Content-Length:
+      - '0'
+      Accept:
+      - ! '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Gdata-User-Country:
+      - PL
+      Gdata-Version:
+      - '2.1'
+      Date:
+      - Thu, 07 Feb 2013 12:11:18 GMT
+      Expires:
+      - Thu, 07 Feb 2013 12:11:18 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '0'
+      Server:
+      - GSE
+      Content-Type:
+      - text/html; charset=UTF-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 07 Feb 2013 12:11:18 GMT
+- request:
+    method: delete
+    uri: http://gdata.youtube.com/feeds/api/users/default/playlists/PLUq7irMdoCZJ_k0AM2vNygREGfaGZowdq
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer ya29.AHES6ZRjjO5OHP2P3EfAKE0eTFwG9kSRey4LLw3-QzDCtXM
+      X-Gdata-Client:
+      - youtube_it
+      X-Gdata-Key:
+      - key=AI39si7WuZZxAkYebKSyrlJR7hIFktt6OoPycEOeOT_yHkZgr6QsGbZgmhKvbS4bsSAv0utgrfhNfXQBITu1wX_z3VsZE02giQ
+      Gdata-Version:
+      - '2'
+      Content-Type:
+      - application/atom+xml; charset=UTF-8
+      Content-Length:
+      - '0'
+      Accept:
+      - ! '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Gdata-User-Country:
+      - PL
+      Gdata-Version:
+      - '2.1'
+      Date:
+      - Thu, 07 Feb 2013 12:11:18 GMT
+      Expires:
+      - Thu, 07 Feb 2013 12:11:18 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '0'
+      Server:
+      - GSE
+      Content-Type:
+      - text/html; charset=UTF-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 07 Feb 2013 12:11:19 GMT
+recorded_with: VCR 2.1.1

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -445,7 +445,21 @@ class TestClient < Test::Unit::TestCase
     video_one = @client.add_video_to_playlist(playlist.playlist_id,"fFAnoEYFUQw")
     video_two = @client.add_video_to_playlist(playlist.playlist_id,"QsbmrCtiEUU")
     wait_for_api
-    assert_equal ["fFAnoEYFUQw", "QsbmrCtiEUU"], @client.playlist(playlist.playlist_id, 'title').videos.map(&:unique_id)
+    assert_equal ["fFAnoEYFUQw", "QsbmrCtiEUU"], @client.playlist(playlist.playlist_id, { 'orderby' => 'title' }).videos.map(&:unique_id)
+    assert @client.delete_video_from_playlist(playlist.playlist_id, video_one[:playlist_entry_id])
+    assert @client.delete_video_from_playlist(playlist.playlist_id, video_two[:playlist_entry_id])
+    assert @client.delete_playlist(playlist.playlist_id)
+  end
+
+  def test_playlist_with_paging_parameters
+    @client.playlists.each{|p| @client.delete_playlist(p.playlist_id)}
+    playlist = @client.add_playlist(:title => "youtube_it test!", :description => "test playlist")
+
+    video_one = @client.add_video_to_playlist(playlist.playlist_id,"fFAnoEYFUQw")
+    video_two = @client.add_video_to_playlist(playlist.playlist_id,"QsbmrCtiEUU")
+    wait_for_api
+    assert_equal ["fFAnoEYFUQw"], @client.playlist(playlist.playlist_id, { 'orderby' => 'title', 'start-index' => 1, 'max-results' => 1 }).videos.map(&:unique_id)
+    assert_equal ["QsbmrCtiEUU"], @client.playlist(playlist.playlist_id, { 'orderby' => 'title', 'start-index' => 2, 'max-results' => 1 }).videos.map(&:unique_id)
     assert @client.delete_video_from_playlist(playlist.playlist_id, video_one[:playlist_entry_id])
     assert @client.delete_video_from_playlist(playlist.playlist_id, video_two[:playlist_entry_id])
     assert @client.delete_playlist(playlist.playlist_id)


### PR DESCRIPTION
Previous implementation only accepted `playlist_id` and `order` Symbol parameter.

This prevented us from
- fetching more than the (default) 25 first videos
- fetching further video pages

I changed `#playlist` implementation to accept `playlist_id` and an `opts` Hash.

**Before**

``` ruby
playlist = client.playlist('PLB821B8F9052B4E11', :position)
```

**After**

``` ruby
playlist = client.playlist 'PLB821B8F9052B4E11',
           { 'orderby' => 'position' }
```

Most important change though: now `start-index` and `max-results` can be passed in the hash, e.g.

``` ruby
playlist = client.playlist 'PLB821B8F9052B4E11',
           { 'orderby'     => 'position',
             'start-index' => 25,
             'max-results' => 5 }
```

Note: this change is not backwards-compatible with code using the older
order parameter, but can be made so by verifying if the second parameter is a Hash or a Symbol
