### PR TITLE
vid parsing regex incorrect

### DIFF
--- a/lib/youtube_it/client.rb
+++ b/lib/youtube_it/client.rb
@@ -85,7 +85,7 @@ class YouTubeIt
     # YouTubeIt::Model::Video
     def video_by(video)
       vid = nil
-      vid_regex = /(?:youtube.com|youtu.be).*(?:\/|v=)([\w-]+)/
+      vid_regex = /(?:youtube.com|youtu.be).*(?:\/|v=)([a-zA-Z0-9_-]+)/
       if video =~ vid_regex
         vid = $1
       else
@@ -175,7 +175,7 @@ class YouTubeIt
     def profiles(*users)
       client.profiles(*users)
     end
-    
+
     def videos(*idxes)
       client.videos(*idxes)
     end

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -187,6 +187,9 @@ class TestClient < Test::Unit::TestCase
   #   video = @client.video_by("http://gdata.youtube.com/feeds/videos/EkF4JD2rO3Q")
   #   assert_valid_video video
 
+  #   video = client.video_by("http://www.youtube.com/watch?v=CBvFZV-jdHY")
+  #   assert_valid_video video
+
   #   video = @client.video_by("EkF4JD2rO3Q")
   #   assert_valid_video video
   # end
@@ -439,7 +442,7 @@ class TestClient < Test::Unit::TestCase
   #   assert_operator videos, :has_key?, 'AByfaYcOm4A'
   #   assert_equal videos['82Wg7DYG9Jc'].title, 'Billboard Hot 100 - Top 50 Singles (4/20/2013)'
   # end
-  
+
   # def test_should_add_and_delete_video_to_favorite
   #   video_id ="fFAnoEYFUQw"
   #   begin
@@ -535,7 +538,7 @@ class TestClient < Test::Unit::TestCase
 
   def test_get_all_videos
     videos = @client.get_all_videos(:user => "enchufetv")
-    assert_equal videos.count, 172
+    assert_equal videos.count, 173
   end
 
   private


### PR DESCRIPTION
Hi, the current vid-parsing regex just uses the "w+" token and doesn't capture hyphens or underscores (which can be in youtube vids). For example, try the following (this is a real youtube video that I was trying to fetch info for in my app):

```
client = YouTubeIt::Client.new
video = client.video_by("http://www.youtube.com/watch?v=CBvFZV-jdHY")
```

Because there's a hyphen in that vid, all that gets parsed out currently is "CBvFZV" and, basically, everything fails. Please merge this when you can (just changed regex to match all alphanumeric strings including hyphens and underscores). I'm monkey-patching over the method right now in an initializer (I'm using the library in a Rails app) to get around this problem, which is pretty critical
