### PR TITLE
add youtube system user name to client.subscriptions query

### DIFF
--- a/lib/youtube_it/model/subscription.rb
+++ b/lib/youtube_it/model/subscription.rb
@@ -1,7 +1,7 @@
 class YouTubeIt
   module Model
     class Subscription < YouTubeIt::Record
-      attr_reader :id, :title, :published
+      attr_reader :id, :title, :published, :youtube_user_name
     end
   end
 end

--- a/lib/youtube_it/parser.rb
+++ b/lib/youtube_it/parser.rb
@@ -360,7 +360,8 @@ class YouTubeIt
         YouTubeIt::Model::Subscription.new(
           :title        => entry.at("title").text,
           :id           => entry.at("id").text[/subscription([^<]+)/, 1].sub(':',''),
-          :published    => entry.at("published") ? entry.at("published").text : nil
+          :published    => entry.at("published") ? entry.at("published").text : nil,
+          :youtube_user_name  => entry.to_s.split(/\<|\>/)[-4]
         )
       end
     end


### PR DESCRIPTION
Ordinally, query "Subscriptions" returns a object, which not include system user name of owner subscription.
I can list this subscription and no more. If youtube user has no "display" representation of your name, this name i can parse from attribute @title from response. So, if yser have human friendly name representation, this will be returned in response and we can't use them in next queryes.

But if i will receive the owner system user name, i will can do query for latest videos of thats users.
I stupidly parsed them by code: entry.to_s.split(/<|>/)[-4] in "parse.rb" file. It's not a good idea, but i'm not understand, how parse this good. Sorry for this.

P.S. sorry for my english
