### PR TITLE
Adding a "content_length" option for remote uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 pkg/
 Gemfile.lock
 *.rbenv*
+*.swp

--- a/lib/youtube_it/request/remote_file.rb
+++ b/lib/youtube_it/request/remote_file.rb
@@ -6,10 +6,12 @@ class YouTubeIt
 
 
     class RemoteFile
-      def initialize( url)
+      def initialize(url, opts)
         @pos = 0
         @url = url
         @uri = URI(@url)
+        
+        @content_length = opts[:content_length]
 
         @fiber = Fiber.new do |first|
 

--- a/lib/youtube_it/request/video_upload.rb
+++ b/lib/youtube_it/request/video_upload.rb
@@ -82,7 +82,7 @@ class YouTubeIt
       def upload(video_data, opts = {})
 
         if video_data.is_a?(String) && uri?(video_data)
-          data = YouTubeIt::Upload::RemoteFile.new(video_data)
+          data = YouTubeIt::Upload::RemoteFile.new(video_data, opts)
         else
           data = video_data
         end


### PR DESCRIPTION
The current remote upload process requires that a HEAD request be sent to the specified URL to get the "content_length" header for the video to be uploaded. To my knowledge, if you use AWS S3 and only allow files in your bucket to be accessed through pre-signed URLs, there is no way to enable HEAD requests to be sent to that URL, so the video_upload method ultimately raises an error when it expects that the content length for the video has been sent. This modification allows the content length to be passed in (optionally) as an option to the video_upload method. 
