### PR TITLE
Add Sandbox Option to HTML5 Embed

### DIFF
--- a/lib/youtube_it/model/video.rb
+++ b/lib/youtube_it/model/video.rb
@@ -259,11 +259,12 @@ EDOC
                 :protocol => params[:protocol] || "http",
                 :frameborder => params[:frameborder] || "0",
                 :url_params => params[:url_params] || {},
-                :sandbox => params[:sandbox] || false
+                :sandbox => params[:sandbox] || false,
+                :fullscreen => params[:fullscreen] || true,
                 }
         url_opts = opts[:url_params].empty? ? "" : "?#{Rack::Utils::build_query(opts[:url_params])}"
         <<EDOC
-<iframe class="#{opts[:class]}" id="#{opts[:id]}" type="text/html" width="#{opts[:width]}" height="#{opts[:height]}" src="#{opts[:protocol]}://www.youtube.com/embed/#{unique_id}#{url_opts}" frameborder="#{opts[:frameborder]}"#{"sandbox=\"#{opts[:sandbox]}\"" if opts[:sandbox]}></iframe>
+<iframe class="#{opts[:class]}" id="#{opts[:id]}" type="text/html" width="#{opts[:width]}" height="#{opts[:height]}" src="#{opts[:protocol]}://www.youtube.com/embed/#{unique_id}#{url_opts}" frameborder="#{opts[:frameborder]}"#{"sandbox=\"#{opts[:sandbox]}\"" if opts[:sandbox]}#{"allowfullscreen" if opts[:fullscreen]}></iframe>
 EDOC
       end
 

--- a/lib/youtube_it/model/video.rb
+++ b/lib/youtube_it/model/video.rb
@@ -258,11 +258,12 @@ EDOC
                 :height => params[:height] || "350",
                 :protocol => params[:protocol] || "http",
                 :frameborder => params[:frameborder] || "0",
-                :url_params => params[:url_params] || {}
+                :url_params => params[:url_params] || {},
+                :sandbox => params[:sandbox] || false
                 }
         url_opts = opts[:url_params].empty? ? "" : "?#{Rack::Utils::build_query(opts[:url_params])}"
         <<EDOC
-<iframe class="#{opts[:class]}" id="#{opts[:id]}" type="text/html" width="#{opts[:width]}" height="#{opts[:height]}" src="#{opts[:protocol]}://www.youtube.com/embed/#{unique_id}#{url_opts}" frameborder="#{opts[:frameborder]}"></iframe>
+<iframe class="#{opts[:class]}" id="#{opts[:id]}" type="text/html" width="#{opts[:width]}" height="#{opts[:height]}" src="#{opts[:protocol]}://www.youtube.com/embed/#{unique_id}#{url_opts}" frameborder="#{opts[:frameborder]}"#{"sandbox=\"#{opts[:sandbox]}\"" if opts[:sandbox]}></iframe>
 EDOC
       end
 

--- a/lib/youtube_it/model/video.rb
+++ b/lib/youtube_it/model/video.rb
@@ -247,24 +247,24 @@ class YouTubeIt
 EDOC
       end
 
-            # Gives you the HTML 5 to embed the video on your website.
-            # Usefull for mobile that not support flash but has html5 browser
-            # === Returns
-            #   String: The HTML for embedding the video on your website.
-            def embed_html5(params = {})
-              opts = {:class  => params[:class]  || "",
-                      :id     => params[:id]     || "",
-                      :width  => params[:width]  || "425",
-                      :height => params[:height] || "350",
-                      :protocol => params[:protocol] || "http",
-                      :frameborder => params[:frameborder] || "0",
-                      :url_params => params[:url_params] || {}
-                      }
-              url_opts = opts[:url_params].empty? ? "" : "?#{Rack::Utils::build_query(opts[:url_params])}"
-              <<EDOC
+      # Gives you the HTML 5 to embed the video on your website.
+      # Usefull for mobile that not support flash but has html5 browser
+      # === Returns
+      #   String: The HTML for embedding the video on your website.
+      def embed_html5(params = {})
+        opts = {:class  => params[:class]  || "",
+                :id     => params[:id]     || "",
+                :width  => params[:width]  || "425",
+                :height => params[:height] || "350",
+                :protocol => params[:protocol] || "http",
+                :frameborder => params[:frameborder] || "0",
+                :url_params => params[:url_params] || {}
+                }
+        url_opts = opts[:url_params].empty? ? "" : "?#{Rack::Utils::build_query(opts[:url_params])}"
+        <<EDOC
 <iframe class="#{opts[:class]}" id="#{opts[:id]}" type="text/html" width="#{opts[:width]}" height="#{opts[:height]}" src="#{opts[:protocol]}://www.youtube.com/embed/#{unique_id}#{url_opts}" frameborder="#{opts[:frameborder]}"></iframe>
 EDOC
-            end
+      end
 
       # Gives you the HTML to embed the video on your website.
       #

--- a/youtube_it.gemspec
+++ b/youtube_it.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.summary     = "The most complete Ruby wrapper for youtube api's"
   s.homepage    = "http://github.com/kylejginavan/youtube_it"
 
-  s.add_runtime_dependency("nokogiri", "~> 1.5.2")
+  s.add_runtime_dependency("nokogiri", "~> 1.5")
   s.add_runtime_dependency("oauth", "~> 0.4.4")
   s.add_runtime_dependency("oauth2", "~> 0.6")
   s.add_runtime_dependency("simple_oauth", ">= 0.1.5")

--- a/youtube_it.gemspec
+++ b/youtube_it.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("builder", ">= 0")
   s.add_runtime_dependency("webmock")
   s.add_runtime_dependency("excon")
-  s.add_runtime_dependency("json", "~> 1.8.0")
+  s.add_runtime_dependency("json", "~> 1.7.7")
   s.files = Dir.glob("lib/**/*") + %w(README.rdoc youtube_it.gemspec)
 
   s.extra_rdoc_files = %w(README.rdoc)


### PR DESCRIPTION
This is important because some PCI compliance providers require the sandbox attribute to be set.
