### PR TITLE
Add User#channel_uri

### DIFF
--- a/lib/youtube_it/model/user.rb
+++ b/lib/youtube_it/model/user.rb
@@ -29,6 +29,7 @@ class YouTubeIt
       attr_reader :view_count
       attr_reader :avatar
       attr_reader :insight_uri
+      attr_reader :channel_uri
     end
   end
 end

--- a/lib/youtube_it/parser.rb
+++ b/lib/youtube_it/parser.rb
@@ -320,7 +320,8 @@ class YouTubeIt
           :videos_watched => entry.at_xpath("yt:statistics")["videoWatchCount"],
           :view_count     => entry.at_xpath("yt:statistics")["viewCount"],
           :upload_views   => entry.at_xpath("yt:statistics")["totalUploadViews"],
-          :insight_uri    => (entry.at_xpath('xmlns:link[@rel="http://gdata.youtube.com/schemas/2007#insight.views"]')['href'] rescue nil)
+          :insight_uri    => (entry.at_xpath('xmlns:link[@rel="http://gdata.youtube.com/schemas/2007#insight.views"]')['href'] rescue nil),
+          :channel_uri    => (entry.at_xpath('xmlns:link[@rel="alternate"]')['href'] rescue nil),
         )
       end
     end

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -411,6 +411,7 @@ class TestClient < Test::Unit::TestCase
 
     assert_equal 'tubeit20101', profile.username
     assert_equal 'tubeit20101', profile.username_display
+    assert_equal 'http://www.youtube.com/channel/UCWWmLvppy3j64IGmA2dpCyw', profile.channel_uri
     assert_instance_of Fixnum, profile.max_upload_duration
     assert_instance_of String, profile.user_id
     assert_nothing_raised{ profile.last_name }


### PR DESCRIPTION
It used to be possible to piece together a working channel url by concatenating the users id with certain url conventions. But due to changes in the url conventions for google+ accounts etc it is now only reliable to get the channel url straight from the profile xml.
