### PR TITLE
Better Exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+2.3.x 2013-xx-xx
+----------------
+
+Changes:
+- All YouTubeIt errors are now defined under the YouTubeIt namespace and inherit from YouTubeIt::Error
+- All 404 responses from the YouTube api now raise YouTubeIt::ResourceNotFoundError instead of UploadError
+
+Improvements:
+- Added this CHANGELOG

--- a/lib/youtube_it.rb
+++ b/lib/youtube_it.rb
@@ -11,15 +11,6 @@ require 'faraday'
 class YouTubeIt
   API_VERSION = "2.1"
 
-  # Base error class for the extension
-  class Error < RuntimeError
-    attr_reader :code
-    def initialize(msg, code = 0)
-      super(msg)
-      @code = code
-    end
-  end
-
   def self.esc(s) #:nodoc:
     CGI.escape(s.to_s)
   end

--- a/lib/youtube_it/client.rb
+++ b/lib/youtube_it/client.rb
@@ -465,9 +465,9 @@ class YouTubeIt
       if (response_code / 10).to_i == 20 # success
         Nokogiri::XML(profile.body).at("//yt:username").text
       elsif response_code == 403 || response_code == 401 # auth failure
-        raise YouTubeIt::Upload::AuthenticationError.new(profile.inspect, response_code)
+        raise AuthenticationError.new(profile.inspect, response_code)
       else
-        raise YouTubeIt::Upload::UploadError.new(profile.inspect, response_code)
+        raise UploadError.new(profile.inspect, response_code)
       end
     end
 
@@ -526,9 +526,9 @@ class YouTubeIt
       if (response_code / 10).to_i == 20 # success
         Nokogiri::XML(profile.body).at("//yt:username").text
       elsif response_code == 403 || response_code == 401 # auth failure
-        raise YouTubeIt::Upload::AuthenticationError.new(profile.inspect, response_code)
+        raise AuthenticationError.new(profile.inspect, response_code)
       else
-        raise YouTubeIt::Upload::UploadError.new(profile.inspect, response_code)
+        raise UploadError.new(profile.inspect, response_code)
       end
     end
 

--- a/lib/youtube_it/middleware/faraday_youtubeit.rb
+++ b/lib/youtube_it/middleware/faraday_youtubeit.rb
@@ -1,8 +1,10 @@
 module Faraday
   class Response::YouTubeIt < Response::Middleware
     def on_complete(env) #this method is called after finish request
-      msg = parse_upload_error_from(env[:body])
-      if env[:status] == 403 || env[:status] == 401
+      msg = parse_error_from(env[:body])
+      if env[:status] == 404
+        raise ::YouTubeIt::ResourceNotFoundError.new(msg)
+      elsif env[:status] == 403 || env[:status] == 401
         raise ::YouTubeIt::AuthenticationError.new(msg, env[:status])
       elsif (env[:status] / 10).to_i != 20
         raise ::YouTubeIt::UploadError.new(msg, env[:status])
@@ -10,7 +12,7 @@ module Faraday
     end
 
     private
-    def parse_upload_error_from(string)
+    def parse_error_from(string)
       return "" unless string
 
       string.gsub!("\n", "")

--- a/lib/youtube_it/request/error.rb
+++ b/lib/youtube_it/request/error.rb
@@ -7,6 +7,12 @@ class YouTubeIt
     end
   end
 
+  class ResourceNotFoundError < Error
+    def initialize(msg)
+      super(msg, 404)
+    end
+  end
+
   class UploadError < Error
   end
 

--- a/lib/youtube_it/request/error.rb
+++ b/lib/youtube_it/request/error.rb
@@ -1,15 +1,15 @@
-class UploadError < YouTubeIt::Error
-  attr_reader :code
-  def initialize(msg, code = 0)
-    super(msg)
-    @code = code
+class YouTubeIt
+  class Error < RuntimeError
+    attr_reader :code
+    def initialize(msg, code = 0)
+      super(msg)
+      @code = code
+    end
   end
-end
 
-class AuthenticationError < YouTubeIt::Error
-  attr_reader :code
-  def initialize(msg, code = 0)
-    super(msg)
-    @code = code
+  class UploadError < Error
+  end
+
+  class AuthenticationError < Error
   end
 end

--- a/lib/youtube_it/request/video_upload.rb
+++ b/lib/youtube_it/request/video_upload.rb
@@ -1,10 +1,5 @@
 class YouTubeIt
   module Upload
-
-    class UploadError < YouTubeIt::Error; end
-
-    class AuthenticationError < YouTubeIt::Error; end
-
     # Implements video uploads/updates/deletions
     #
     #   require 'youtube_it'
@@ -590,7 +585,7 @@ class YouTubeIt
           http  = Faraday.new("https://www.google.com", :ssl => {:verify => false})
           body = "Email=#{YouTubeIt.esc @user}&Passwd=#{YouTubeIt.esc @password}&service=youtube&source=#{YouTubeIt.esc @client_id}"
           response = http.post("/accounts/ClientLogin", body, "Content-Type" => "application/x-www-form-urlencoded")
-          raise ::AuthenticationError.new(response.body[/Error=(.+)/,1], response.status.to_i) if response.status.to_i != 200
+          raise ::YouTubeIt::AuthenticationError.new(response.body[/Error=(.+)/,1], response.status.to_i) if response.status.to_i != 200
           @auth_token = response.body[/Auth=(.+)/, 1]
         end
       end

--- a/test/cassettes/raise_error_on_private_video.yml
+++ b/test/cassettes/raise_error_on_private_video.yml
@@ -1,0 +1,132 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://gdata.youtube.com/feeds/api/users/default
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Authorization:
+      - Bearer ya29.AHES6ZSZn8ZzSlwse_osmNbzQm8URi6JTb2h9NnrGu4OxC0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Gdata-User-Country:
+      - SE
+      Content-Type:
+      - application/atom+xml; charset=UTF-8
+      Expires:
+      - Mon, 02 Sep 2013 10:14:21 GMT
+      Date:
+      - Mon, 02 Sep 2013 10:14:21 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Accept, X-GData-Authorization, GData-Version
+      Gdata-Version:
+      - '1.0'
+      Last-Modified:
+      - Wed, 07 Aug 2013 16:38:26 GMT
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alternate-Protocol:
+      - 80:quic
+    body:
+      encoding: UTF-8
+      string: <?xml version='1.0' encoding='UTF-8'?><entry xmlns='http://www.w3.org/2005/Atom'
+        xmlns:media='http://search.yahoo.com/mrss/' xmlns:gd='http://schemas.google.com/g/2005'
+        xmlns:yt='http://gdata.youtube.com/schemas/2007'><id>http://gdata.youtube.com/feeds/api/users/WWmLvppy3j64IGmA2dpCyw</id><published>2010-07-06T14:59:05.000Z</published><updated>2013-08-07T16:38:26.000Z</updated><category
+        scheme='http://schemas.google.com/g/2005#kind' term='http://gdata.youtube.com/schemas/2007#userProfile'/><title
+        type='text'>tubeit20101</title><content type='text'/><link rel='alternate'
+        type='text/html' href='http://www.youtube.com/channel/UCWWmLvppy3j64IGmA2dpCyw'/><link
+        rel='http://gdata.youtube.com/schemas/2007#insight.views' type='text/html'
+        href='https://insight.youtube.com/video-analytics-partner/gwt/csv-zip?token=CiAKAghKEhoIABIWV1dtTHZwcHkzajY0SUdtQTJkcEN5dw&amp;sig=MC0CFDdqHmJesV4Vmnuxdi18j3zxvGT5AhUAi4VFYXLVC0jkW7I1TJgYed48X6k&amp;user_starttime=1377388800000&amp;user_endtime=1377993600000&amp;exp=1378120460836'/><link
+        rel='self' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/users/WWmLvppy3j64IGmA2dpCyw'/><author><name>tubeit20101</name><uri>http://gdata.youtube.com/feeds/api/users/tubeit20101</uri></author><yt:age>31</yt:age><gd:feedLink
+        rel='http://gdata.youtube.com/schemas/2007#user.subscriptions' href='http://gdata.youtube.com/feeds/api/users/tubeit20101/subscriptions'
+        countHint='0'/><gd:feedLink rel='http://gdata.youtube.com/schemas/2007#user.contacts'
+        href='http://gdata.youtube.com/feeds/api/users/tubeit20101/contacts' countHint='0'/><gd:feedLink
+        rel='http://gdata.youtube.com/schemas/2007#user.inbox' href='http://gdata.youtube.com/feeds/api/users/tubeit20101/inbox'
+        countHint='0'/><gd:feedLink rel='http://gdata.youtube.com/schemas/2007#user.playlists'
+        href='http://gdata.youtube.com/feeds/api/users/tubeit20101/playlists'/><gd:feedLink
+        rel='http://gdata.youtube.com/schemas/2007#user.uploads' href='http://gdata.youtube.com/feeds/api/users/tubeit20101/uploads'
+        countHint='41'/><gd:feedLink rel='http://gdata.youtube.com/schemas/2007#user.newsubscriptionvideos'
+        href='http://gdata.youtube.com/feeds/api/users/tubeit20101/newsubscriptionvideos'/><yt:location>AR</yt:location><yt:maxUploadDuration
+        seconds='930'/><yt:statistics lastWebAccess='1970-01-01T00:00:00.000Z' subscriberCount='0'
+        videoWatchCount='0' viewCount='0' totalUploadViews='0'/><media:thumbnail url='http://s.ytimg.com/yts/img/silhouette250-vflEqxKg9.png'/><yt:username>tubeit20101</yt:username></entry>
+    http_version:
+  recorded_at: Mon, 02 Sep 2013 10:14:21 GMT
+- request:
+    method: get
+    uri: http://gdata.youtube.com/feeds/api/users/default/uploads/0KI_osldHWg
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Authorization:
+      - Bearer ya29.AHES6ZSZn8ZzSlwse_osmNbzQm8URi6JTb2h9NnrGu4OxC0
+      X-Gdata-Client:
+      - youtube_it
+      X-Gdata-Key:
+      - key=AI39si7WuZZxAkYebKSyrlJR7hIFktt6OoPycEOeOT_yHkZgr6QsGbZgmhKvbS4bsSAv0utgrfhNfXQBITu1wX_z3VsZE02giQ
+      Gdata-Version:
+      - '2.1'
+      Content-Type:
+      - application/atom+xml; charset=UTF-8
+      Content-Length:
+      - '0'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      X-Gdata-User-Country:
+      - SE
+      Content-Type:
+      - application/vnd.google.gdata.error+xml
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 02 Sep 2013 10:16:53 GMT
+      Expires:
+      - Mon, 02 Sep 2013 10:16:53 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alternate-Protocol:
+      - 80:quic
+    body:
+      encoding: UTF-8
+      string: <errors xmlns='http://schemas.google.com/g/2005'><error><domain>GData</domain><code>ServiceForbiddenException</code><internalReason>Private video</internalReason></error></errors>
+    http_version:
+  recorded_at: Mon, 02 Sep 2013 10:16:53 GMT
+recorded_with: VCR 2.5.0

--- a/test/cassettes/raise_error_on_video_not_found.yml
+++ b/test/cassettes/raise_error_on_video_not_found.yml
@@ -1,0 +1,132 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://gdata.youtube.com/feeds/api/users/default
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.7
+      Authorization:
+      - Bearer ya29.AHES6ZSQ5njt5VZGfAo6FSDnptJM3Qiq1ixW7GUluiMcJ20
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Gdata-User-Country:
+      - AR
+      Content-Type:
+      - application/atom+xml; charset=UTF-8
+      Expires:
+      - Thu, 27 Jun 2013 23:03:12 GMT
+      Date:
+      - Thu, 27 Jun 2013 23:03:12 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Accept, X-GData-Authorization, GData-Version
+      Gdata-Version:
+      - '1.0'
+      Last-Modified:
+      - Thu, 27 Jun 2013 22:54:50 GMT
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+    body:
+      encoding: US-ASCII
+      string: <?xml version='1.0' encoding='UTF-8'?><entry xmlns='http://www.w3.org/2005/Atom'
+        xmlns:media='http://search.yahoo.com/mrss/' xmlns:gd='http://schemas.google.com/g/2005'
+        xmlns:yt='http://gdata.youtube.com/schemas/2007'><id>http://gdata.youtube.com/feeds/api/users/WWmLvppy3j64IGmA2dpCyw</id><published>2010-07-06T14:59:05.000Z</published><updated>2013-06-27T22:54:50.000Z</updated><category
+        scheme='http://schemas.google.com/g/2005#kind' term='http://gdata.youtube.com/schemas/2007#userProfile'/><title
+        type='text'>tubeit20101</title><content type='text'/><link rel='alternate'
+        type='text/html' href='http://www.youtube.com/channel/UCWWmLvppy3j64IGmA2dpCyw'/><link
+        rel='http://gdata.youtube.com/schemas/2007#insight.views' type='text/html'
+        href='https://insight.youtube.com/video-analytics-partner/gwt/csv-zip?token=CiAKAghKEhoIABIWV1dtTHZwcHkzajY0SUdtQTJkcEN5dw&amp;sig=MC4CFQCRa_2lgCK5seTYrB1Sb_y_IOWSFAIVALfxEihhMNCqJO2OJRjWguaAJB7T&amp;user_starttime=1371600000000&amp;user_endtime=1372204800000&amp;exp=1372377792022'/><link
+        rel='self' type='application/atom+xml' href='http://gdata.youtube.com/feeds/api/users/WWmLvppy3j64IGmA2dpCyw'/><author><name>tubeit20101</name><uri>http://gdata.youtube.com/feeds/api/users/tubeit20101</uri></author><yt:age>31</yt:age><gd:feedLink
+        rel='http://gdata.youtube.com/schemas/2007#user.subscriptions' href='http://gdata.youtube.com/feeds/api/users/tubeit20101/subscriptions'
+        countHint='0'/><gd:feedLink rel='http://gdata.youtube.com/schemas/2007#user.contacts'
+        href='http://gdata.youtube.com/feeds/api/users/tubeit20101/contacts' countHint='0'/><gd:feedLink
+        rel='http://gdata.youtube.com/schemas/2007#user.inbox' href='http://gdata.youtube.com/feeds/api/users/tubeit20101/inbox'
+        countHint='0'/><gd:feedLink rel='http://gdata.youtube.com/schemas/2007#user.playlists'
+        href='http://gdata.youtube.com/feeds/api/users/tubeit20101/playlists'/><gd:feedLink
+        rel='http://gdata.youtube.com/schemas/2007#user.uploads' href='http://gdata.youtube.com/feeds/api/users/tubeit20101/uploads'
+        countHint='36'/><gd:feedLink rel='http://gdata.youtube.com/schemas/2007#user.newsubscriptionvideos'
+        href='http://gdata.youtube.com/feeds/api/users/tubeit20101/newsubscriptionvideos'/><yt:location>AR</yt:location><yt:maxUploadDuration
+        seconds='930'/><yt:statistics lastWebAccess='1970-01-01T00:00:00.000Z' subscriberCount='0'
+        videoWatchCount='0' viewCount='104' totalUploadViews='0'/><media:thumbnail
+        url='http://s.ytimg.com/yts/img/silhouette250-vflEqxKg9.png'/><yt:username>tubeit20101</yt:username></entry>
+    http_version: 
+  recorded_at: Thu, 27 Jun 2013 23:03:20 GMT
+- request:
+    method: get
+    uri: http://gdata.youtube.com/feeds/api/users/default/uploads/nonexisting
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Authorization:
+      - Bearer ya29.AHES6ZSZn8ZzSlwse_osmNbzQm8URi6JTb2h9NnrGu4OxC0
+      X-Gdata-Client:
+      - youtube_it
+      X-Gdata-Key:
+      - key=AI39si7WuZZxAkYebKSyrlJR7hIFktt6OoPycEOeOT_yHkZgr6QsGbZgmhKvbS4bsSAv0utgrfhNfXQBITu1wX_z3VsZE02giQ
+      Gdata-Version:
+      - '2.1'
+      Content-Type:
+      - application/atom+xml; charset=UTF-8
+      Content-Length:
+      - '0'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      X-Gdata-User-Country:
+      - SE
+      Content-Type:
+      - application/vnd.google.gdata.error+xml
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 02 Sep 2013 10:04:31 GMT
+      Expires:
+      - Mon, 02 Sep 2013 10:04:31 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alternate-Protocol:
+      - 80:quic
+    body:
+      encoding: UTF-8
+      string: <errors xmlns='http://schemas.google.com/g/2005'><error><domain>GData</domain><code>ResourceNotFoundException</code><internalReason>Video
+        not found</internalReason></error></errors>
+    http_version: 
+  recorded_at: Mon, 02 Sep 2013 10:04:31 GMT
+recorded_with: VCR 2.5.0

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -378,7 +378,7 @@ class TestClient < Test::Unit::TestCase
   end
 
   def test_should_raise_error_on_video_not_found
-    exception = assert_raise(YouTubeIt::UploadError) { @client.my_video("nonexisting") }
+    exception = assert_raise(YouTubeIt::ResourceNotFoundError) { @client.my_video("nonexisting") }
     assert_equal 404, exception.code
     assert_equal "Video not found: ResourceNotFoundException\n", exception.message
   end

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -377,6 +377,18 @@ class TestClient < Test::Unit::TestCase
     @client.video_delete(video.unique_id)
   end
 
+  def test_should_raise_error_on_video_not_found
+    exception = assert_raise(YouTubeIt::UploadError) { @client.my_video("nonexisting") }
+    assert_equal 404, exception.code
+    assert_equal "Video not found: ResourceNotFoundException\n", exception.message
+  end
+
+  def test_should_raise_error_on_private_video
+    exception = assert_raise(YouTubeIt::AuthenticationError) { @client.my_video("0KI_osldHWg") }
+    assert_equal 403, exception.code
+    assert_equal "Private video: ServiceForbiddenException\n", exception.message
+  end
+
   def test_should_add_like_to_video
     r = @client.like_video("CE62FSEoY28")
     assert_equal r[:code], 201

--- a/youtube_it.gemspec
+++ b/youtube_it.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("json", "~> 1.8.0")
   s.files = Dir.glob("lib/**/*") + %w(README.rdoc youtube_it.gemspec)
 
-  s.extra_rdoc_files = %w(README.rdoc)
+  s.extra_rdoc_files = %w(README.rdoc CHANGELOG.md)
 end
 


### PR DESCRIPTION
Pull request for the previously added (and in theory approved) issue #160.
- All errors are now defined under the YouTubeIt namespace and inherit from YouTubeIt::Error
- All 404 responses from the YouTube api now raise YouTubeIt::ResourceNotFoundError instead of UploadError

Note that some tests for the handling of errors have been added, making the code more robust overall.

Also adds a change log since it's crucial to inform people using the gem of what's being changed between versions. Whenever you actually release a new gem version make sure to set the appropriate version number and date info in the changelog as well.
