### PR TITLE
retrieve region-specific and category-specific standardfeeds

### DIFF
--- a/lib/youtube_it/request/standard_search.rb
+++ b/lib/youtube_it/request/standard_search.rb
@@ -5,6 +5,8 @@ class YouTubeIt
       attr_reader :order_by                        # orderby, ([relevance], viewCount, published, rating)
       attr_reader :offset                          # start-index
       attr_reader :time                            # time
+      attr_reader :region                          # region
+      attr_reader :category                        # category
 
       TYPES = [ :top_rated, :top_favorites, :most_viewed, :most_popular,
                 :most_recent, :most_discussed, :most_linked, :most_responded,
@@ -15,7 +17,11 @@ class YouTubeIt
         if TYPES.include?(type)
           @max_results, @order_by, @offset, @time = nil
           set_instance_variables(options)
-          @url = base_url + type.to_s << build_query_params(to_youtube_params)
+          @url = base_url
+          @url << @region << "/" if @region
+          @url << type.to_s
+          @url << "_" << @category if @category
+          @url << build_query_params(to_youtube_params)
         else
           raise "Invalid type, must be one of: #{ TYPES.map { |t| t.to_s }.join(", ") }"
         end

--- a/test/test_video_search.rb
+++ b/test/test_video_search.rb
@@ -78,6 +78,17 @@ class TestVideoSearch < Test::Unit::TestCase
     assert_equal "http://gdata.youtube.com/feeds/api/standardfeeds/top_rated?max-results=10&start-index=5&time=today&v=#{YouTubeIt::API_VERSION}", request.url
   end
 
+  def test_should_build_url_for_most_viewed_region_ru_offset_and_max_results_with_time
+    request = YouTubeIt::Request::StandardSearch.new(:top_rated, :offset => 5, :max_results => 10, :time => :today, :region => "RU")
+    assert_equal "http://gdata.youtube.com/feeds/api/standardfeeds/RU/top_rated?max-results=10&start-index=5&time=today&v=#{YouTubeIt::API_VERSION}", request.url
+  end
+
+  def test_should_build_url_for_most_viewed_region_ru_category_news_offset_and_max_results_with_time
+    request = YouTubeIt::Request::StandardSearch.new(:top_rated, :offset => 5, :max_results => 10, :time => :today, :region => "RU", :category => "News")
+    assert_equal "http://gdata.youtube.com/feeds/api/standardfeeds/RU/top_rated_News?max-results=10&start-index=5&time=today&v=#{YouTubeIt::API_VERSION}", request.url
+  end
+
+
   def test_should_raise_exception_for_invalid_type
     assert_raise RuntimeError do
       request = YouTubeIt::Request::StandardSearch.new(:most_viewed_yo)


### PR DESCRIPTION
Use region-specific and category-specific filters for the standardfeeds
https://developers.google.com/youtube/2.0/developers_guide_protocol_video_feeds

eg:
YouTubeIt::Request::StandardSearch.new(:top_rated, :offset => 5, :max_results => 10, :time => :today, :region => "RU", :category => "News")
