### PR TITLE
Fixes media content format parsing

### DIFF
--- a/lib/youtube_it/parser.rb
+++ b/lib/youtube_it/parser.rb
@@ -574,7 +574,7 @@ class YouTubeIt
 
       def parse_media_content (elem)
         content_url = elem["url"]
-        format_code = elem["format"].to_i
+        format_code = elem["yt:format"].to_i
         format = YouTubeIt::Model::Video::Format.by_code(format_code)
         duration = elem["duration"].to_i
         mime_type = elem["type"]

--- a/test/test_video_feed_parser.rb
+++ b/test/test_video_feed_parser.rb
@@ -270,6 +270,14 @@ class TestVideoFeedParser < Test::Unit::TestCase
     end
   end
 
+  def test_should_parse_format_code_of_media_contents_correctly
+    with_video_response do |parser|
+      video = parser.parse
+      content = video.media_content.first
+      assert_equal YouTubeIt::Model::Video::Format.by_code(5), content.format
+    end
+  end
+
   def with_video_response(file = "/files/youtube_video_response.xml", &block)
     File.open(File.dirname(__FILE__) + file) do |xml|
       parser = YouTubeIt::Parser::VideoFeedParser.new xml.read


### PR DESCRIPTION
Parser currently returns 0 for the format code as the attribute prefix is missing when assigning the value
