### PR TITLE
Add channel_id and gp_user_id to Comment

### DIFF
--- a/lib/youtube_it/model/comment.rb
+++ b/lib/youtube_it/model/comment.rb
@@ -5,6 +5,7 @@ class YouTubeIt
 
       # YouTubeIt::Model::Author:: Information about the YouTube user who owns a piece of video content.
       attr_reader :author
+      attr_reader :channel_id
 
       # unique ID of the comment.
       def unique_id

--- a/lib/youtube_it/model/comment.rb
+++ b/lib/youtube_it/model/comment.rb
@@ -6,6 +6,7 @@ class YouTubeIt
       # YouTubeIt::Model::Author:: Information about the YouTube user who owns a piece of video content.
       attr_reader :author
       attr_reader :channel_id
+      attr_reader :gp_user_id
 
       # unique ID of the comment.
       def unique_id

--- a/lib/youtube_it/parser.rb
+++ b/lib/youtube_it/parser.rb
@@ -62,7 +62,8 @@ class YouTubeIt
             :title     => remove_bom(entry.at("title").text),
             :updated   => entry.at("updated").text,
             :url       => entry.at("id").text,
-            :reply_to  => parse_reply(entry)
+            :reply_to  => parse_reply(entry),
+            :channel_id => (entry.at("yt|channelId").text rescue nil)
           )
         end
 

--- a/lib/youtube_it/parser.rb
+++ b/lib/youtube_it/parser.rb
@@ -63,7 +63,8 @@ class YouTubeIt
             :updated   => entry.at("updated").text,
             :url       => entry.at("id").text,
             :reply_to  => parse_reply(entry),
-            :channel_id => (entry.at("yt|channelId").text rescue nil)
+            :channel_id => (entry.at("yt|channelId").text rescue nil),
+            :gp_user_id => (entry.at("yt|googlePlusUserId").text rescue nil)
           )
         end
 

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -627,6 +627,7 @@ class TestClient < Test::Unit::TestCase
       assert_equal c1.updated, c2.updated
       assert_equal c1.url, c2.url
       assert_equal c1.author.name, c2.author.name
+      assert_equal c1.channel_id, c2.channel_id
     end
 
     def assert_valid_url (url)

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -628,6 +628,7 @@ class TestClient < Test::Unit::TestCase
       assert_equal c1.url, c2.url
       assert_equal c1.author.name, c2.author.name
       assert_equal c1.channel_id, c2.channel_id
+      assert_equal c1.gp_user_id, c2.gp_user_id
     end
 
     def assert_valid_url (url)


### PR DESCRIPTION
YouTube also provides the yt:channelId and yt:googlePlusUserId.
