### PR TITLE
specify webmock as a development dependency

### DIFF
--- a/youtube_it.gemspec
+++ b/youtube_it.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("simple_oauth", ">= 0.1.5")
   s.add_runtime_dependency("faraday", "~> 0.8")
   s.add_runtime_dependency("builder", ">= 0")
-  s.add_runtime_dependency("webmock")
   s.add_runtime_dependency("excon")
   s.add_runtime_dependency("json", "~> 1.7.7")
+  s.add_development_dependency("webmock")
   s.files = Dir.glob("lib/**/*") + %w(README.rdoc youtube_it.gemspec)
 
   s.extra_rdoc_files = %w(README.rdoc CHANGELOG.md)


### PR DESCRIPTION
It should be a development dependency.
