### PR TITLE
bump faraday dependency

### DIFF
--- a/youtube_it.gemspec
+++ b/youtube_it.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("oauth", "~> 0.4.4")
   s.add_runtime_dependency("oauth2", "~> 0.6")
   s.add_runtime_dependency("simple_oauth", ">= 0.1.5")
-  s.add_runtime_dependency("faraday", "~> 0.8")
+  s.add_runtime_dependency("faraday", ['>= 0.8', '< 0.10'])
   s.add_runtime_dependency("builder", ">= 0")
   s.add_runtime_dependency("webmock")
   s.add_runtime_dependency("excon")


### PR DESCRIPTION
allow using latest version of faraday 0.9 :)

would be great to release new version after merging this PR :100: 
