### PR TITLE
Update README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -79,6 +79,7 @@ Basic Queries:
   $ client.videos_by(:query => "penguin")
   $ client.videos_by(:query => "penguin", :page => 2, :per_page => 15)
   $ client.videos_by(:query => "penguin", :restriction => "DE")
+  $ client.videos_by(:query => "penguin",  :author => "liz")
   $ client.videos_by(:tags => ['tiger', 'leopard'])
   $ client.videos_by(:categories => [:news, :sports])
   $ client.videos_by(:categories => [:news, :sports], :tags => ['soccer', 'football'])


### PR DESCRIPTION
Added example on how to search for videos based on query and user.

The desired query:
    https://www.youtube.com/user/Vsauce/search?query=some+surprising+things

Searching for videos based on query and user doesn't work with the following example:
`client.videos_by(:user => 'vsauce', :query => "some surprising things")`

After looking playing around with different parameters I found the solution. 
`client.videos_by(:author => 'vsauce', :query => "some surprising things")`

Not sure why this doesn't work with user but author, but I added an example in README for future users stumbling across this problem.

https://github.com/kylejginavan/youtube_it/issues/223
