### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 rvm:
-  - 2.0.0
+  - 2.1
+  - 2.0
   - 1.9.3
 
 script: bundle exec rake test

--- a/youtube_it.gemspec
+++ b/youtube_it.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("nokogiri", "~> 1.6.0")
   s.add_runtime_dependency("oauth", "~> 0.4.4")
-  s.add_runtime_dependency("oauth2", "~> 0.6")
+  s.add_runtime_dependency("oauth2", "~> 1.0.0")
   s.add_runtime_dependency("simple_oauth", ">= 0.1.5")
   s.add_runtime_dependency("faraday", ['>= 0.8', '< 0.10'])
   s.add_runtime_dependency("builder", ">= 0")
@@ -27,4 +27,3 @@ Gem::Specification.new do |s|
 
   s.extra_rdoc_files = %w(README.rdoc CHANGELOG.md)
 end
-


### PR DESCRIPTION
Include 2.1.x into the travis build, and updates the version syntax to the new ruby version syntax.
