### PR TITLE
Explicitly requiring a ruby version for this gem

### DIFF
--- a/youtube_it.gemspec
+++ b/youtube_it.gemspec
@@ -14,7 +14,8 @@ Gem::Specification.new do |s|
   s.summary     = "The most complete Ruby wrapper for youtube api's"
   s.homepage    = "http://github.com/kylejginavan/youtube_it"
   s.license     = 'MIT'
-
+  
+  s.required_ruby_version = ">= 1.9.2"
   s.add_runtime_dependency("nokogiri", "~> 1.6.0")
   s.add_runtime_dependency("oauth", "~> 0.4.4")
   s.add_runtime_dependency("oauth2", "~> 1.0.0")


### PR DESCRIPTION
Since it's only possible to use youtube_it with ruby >= 1.9.2, I think it's a good idea to be explicit about it an save developers time when checking the interpreter compatibility status.
